### PR TITLE
Avoid find on remove node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Avoid unnecessary find() when removing a node. [#5](https://github.com/tzaeschke/phtree-cpp/issues/5)
 - Avoid unnecessary key copy when inserting a node. [#4](https://github.com/tzaeschke/phtree-cpp/issues/4)
 - for_each(callback, filter) was traversing too many nodes. [#2](https://github.com/tzaeschke/phtree-cpp/issues/2)
 - Build improvements for bazel/cmake

--- a/phtree/v16/iterator_base.h
+++ b/phtree/v16/iterator_base.h
@@ -135,8 +135,8 @@ class IteratorBase {
      * The parent entry contains the parent node. The parent node is the node ABOVE the current node
      * which contains the current entry.
      */
-    const EntryT* GetCurrentNodeEntry() const {
-        return current_node_;
+    EntryT* GetCurrentNodeEntry() const {
+        return const_cast<EntryT*>(current_node_);
     }
 
     const EntryT* GetParentNodeEntry() const {

--- a/phtree/v16/phtree_v16.h
+++ b/phtree/v16/phtree_v16.h
@@ -247,17 +247,14 @@ class PhTreeV16 {
         if (iterator.Finished()) {
             return 0;
         }
-        if (!iterator.GetParentNodeEntry()) {
-            // Why may there be no parent?
-            // - we are in the root node
-            // - the iterator did not set this value
-            // In either case, we need to start searching from the top.
-            return erase(iterator.GetCurrentResult()->GetKey());
+         if (!iterator.GetCurrentNodeEntry() || iterator.GetCurrentNodeEntry() == &root_) {
+             // There may be no entry because not every iterator sets it.
+             // Also, do _not_ use the root entry, see erase(key).
+             // Start searching from the top.
+             return erase(iterator.GetCurrentResult()->GetKey());
         }
         bool found = false;
         assert(iterator.GetCurrentNodeEntry() && iterator.GetCurrentNodeEntry()->IsNode());
-        // See erase()
-        assert(iterator.GetCurrentNodeEntry() != &root_);
         iterator.GetCurrentNodeEntry()->GetNode().Erase(
             iterator.GetCurrentResult()->GetKey(),
             iterator.GetCurrentNodeEntry(),

--- a/phtree/v16/phtree_v16.h
+++ b/phtree/v16/phtree_v16.h
@@ -57,7 +57,6 @@ class PhTreeV16 {
     using ScalarExternal = typename CONVERT::ScalarExternal;
     using ScalarInternal = typename CONVERT::ScalarInternal;
     using KeyT = typename CONVERT::KeyInternal;
-    using NodeT = Node<DIM, T, ScalarInternal>;
     using EntryT = Entry<DIM, T, ScalarInternal>;
 
   public:
@@ -216,13 +215,16 @@ class PhTreeV16 {
      * @return '1' if a value was found, otherwise '0'.
      */
     size_t erase(const KeyT& key) {
-        auto* current_node = &root_.GetNode();
-        NodeT* parent_node = nullptr;
+        auto* current_entry = &root_;
+        // We do not pass in the root entry as parent of a node because we do not want the
+        // root entry to be modified. The reason is simply that a lot of the code in this class
+        // becomes a lot simpler if we can assume the root entry to contain a node.
+        EntryT* non_root_current_entry = nullptr;
         bool found = false;
-        while (current_node) {
-            auto* child_node = current_node->Erase(key, parent_node, found);
-            parent_node = current_node;
-            current_node = child_node;
+        while (current_entry) {
+            auto* child_entry = current_entry->GetNode().Erase(key, non_root_current_entry, found);
+            current_entry = child_entry;
+            non_root_current_entry = child_entry;
         }
         num_entries_ -= found;
         return found;
@@ -254,9 +256,11 @@ class PhTreeV16 {
         }
         bool found = false;
         assert(iterator.GetCurrentNodeEntry() && iterator.GetCurrentNodeEntry()->IsNode());
+        // See erase()
+        assert(iterator.GetCurrentNodeEntry() != &root_);
         iterator.GetCurrentNodeEntry()->GetNode().Erase(
             iterator.GetCurrentResult()->GetKey(),
-            &iterator.GetParentNodeEntry()->GetNode(),
+            iterator.GetCurrentNodeEntry(),
             found);
 
         num_entries_ -= found;


### PR DESCRIPTION
This change removes a find() operation in a parent node when removing a child node, see issue #5 