### PR TITLE
Fix/issue 9 entry union

### DIFF
--- a/phtree/benchmark/insert_d_benchmark.cc
+++ b/phtree/benchmark/insert_d_benchmark.cc
@@ -31,6 +31,7 @@ const double GLOBAL_MAX = 10000;
  */
 template <dimension_t DIM>
 class IndexBenchmark {
+    using Index = PhTreeD<DIM, std::int32_t>;
   public:
     IndexBenchmark(benchmark::State& state, TestGenerator data_type, int num_entities);
 
@@ -39,7 +40,7 @@ class IndexBenchmark {
   private:
     void SetupWorld(benchmark::State& state);
 
-    void Insert(benchmark::State& state, PhTreeD<DIM, int>& tree);
+    void Insert(benchmark::State& state, Index& tree);
 
     const TestGenerator data_type_;
     const int num_entities_;
@@ -58,7 +59,7 @@ template <dimension_t DIM>
 void IndexBenchmark<DIM>::Benchmark(benchmark::State& state) {
     for (auto _ : state) {
         state.PauseTiming();
-        auto* tree = new PhTreeD<DIM, int>();
+        auto* tree = new Index();
         state.ResumeTiming();
 
         Insert(state, *tree);
@@ -82,7 +83,7 @@ void IndexBenchmark<DIM>::SetupWorld(benchmark::State& state) {
 }
 
 template <dimension_t DIM>
-void IndexBenchmark<DIM>::Insert(benchmark::State& state, PhTreeD<DIM, int>& tree) {
+void IndexBenchmark<DIM>::Insert(benchmark::State& state, Index& tree) {
     for (int i = 0; i < num_entities_; ++i) {
         PhPointD<DIM>& p = points_[i];
         tree.emplace(p, i);

--- a/phtree/phtree_d_test.cc
+++ b/phtree/phtree_d_test.cc
@@ -48,7 +48,10 @@ struct Id {
         return _i == rhs._i;
     }
 
+    Id(Id const& rhs) = default;
+    Id(Id && rhs) = default;
     Id& operator=(Id const& rhs) = default;
+    Id& operator=(Id && rhs) = default;
 
     int _i;
 };

--- a/phtree/phtree_test.cc
+++ b/phtree/phtree_test.cc
@@ -233,7 +233,9 @@ void SmokeTestBasicOps(size_t N) {
     ASSERT_TRUE(tree.empty());
     PhTreeDebugHelper::CheckConsistency(tree);
 
-    ASSERT_EQ(construct_count_ + copy_construct_count_ + move_construct_count_, destruct_count_);
+    // Normal construction and destruction should be symmetric. Move-construction is ignored.
+    ASSERT_GE(construct_count_ + copy_construct_count_ + move_construct_count_, destruct_count_);
+    ASSERT_LE(construct_count_ + copy_construct_count_, destruct_count_);
     // The following assertions exist only as sanity checks and may need adjusting.
     // There is nothing fundamentally wrong if a change in the implementation violates
     // any of the following assertions, as long as performance/memory impact is observed.

--- a/phtree/phtree_test.cc
+++ b/phtree/phtree_test.cc
@@ -76,6 +76,20 @@ struct Id {
         _i = other._i;
     }
 
+//    Id& operator=(const Id& other) = default;
+//    Id& operator=(Id&& other) = default;
+
+    Id& operator=(const Id& other) noexcept {
+        ++copy_assign_count_;
+        _i = other._i;
+        return *this;
+    }
+    Id& operator=(Id&& other)  noexcept {
+        ++move_assign_count_;
+        _i = other._i;
+        return *this;
+    }
+
     bool operator==(const Id& rhs) const {
         ++copy_assign_count_;
         return _i == rhs._i;
@@ -89,8 +103,6 @@ struct Id {
     ~Id() {
         ++destruct_count_;
     }
-
-    Id& operator=(Id const& rhs) = default;
 
     int _i;
 };

--- a/phtree/v16/entry.h
+++ b/phtree/v16/entry.h
@@ -23,14 +23,19 @@
 #include <memory>
 #include <optional>
 
+//#define PH_TREE_ENTRY_POSTLEN 1
+
 namespace improbable::phtree::v16 {
 
 template <dimension_t DIM, typename T, typename SCALAR>
 class Node;
 
+template <dimension_t DIM, typename T, typename SCALAR>
+struct EntryVariant;
+
 /*
- * Nodes in the PH-Tree contain up to 2^DIM PhEntries, one in each geometric quadrant.
- * PhEntries can contain two types of data:
+ * Nodes in the PH-Tree contain up to 2^DIM Entries, one in each geometric quadrant.
+ * Entries can contain two types of data:
  * - A key/value pair (value of type T)
  * - A prefix/child-node pair, where prefix is the prefix of the child node and the
  *   child node is contained in a unique_ptr.
@@ -46,82 +51,291 @@ class Entry {
      * Construct entry with existing node.
      */
     Entry(const KeyT& k, std::unique_ptr<NodeT>&& node_ptr)
-    : kd_key_{k}, node_{std::move(node_ptr)}, value_{std::nullopt} {}
+    : kd_key_{k}
+    , variant_{std::move(node_ptr)}
+#ifdef PH_TREE_ENTRY_POSTLEN
+    , postfix_len_{variant_.GetNode().GetPostfixLen()}
+#endif
+    {
+    }
 
     /*
      * Construct entry with a new node.
      */
     Entry(bit_width_t infix_len, bit_width_t postfix_len)
-    : kd_key_(), node_{std::make_unique<NodeT>(infix_len, postfix_len)}, value_{std::nullopt} {}
+    : kd_key_()
+    , variant_{std::make_unique<NodeT>(infix_len, postfix_len)}
+#ifdef PH_TREE_ENTRY_POSTLEN
+    , postfix_len_{postfix_len}
+#endif
+    {
+    }
 
     /*
      * Construct entry with existing T.
      */
     Entry(const KeyT& k, std::optional<ValueT>&& value)
-    : kd_key_{k}, node_{nullptr}, value_{std::move(value)} {}
+    : kd_key_{k}
+    , variant_{std::move(value)}
+#ifdef PH_TREE_ENTRY_POSTLEN
+    , postfix_len_{0}
+#endif
+    {
+    }
 
     /*
      * Construct entry with new T or moved T.
      */
     template <typename... Args>
     explicit Entry(const KeyT& k, Args&&... args)
-    : kd_key_{k}, node_{nullptr}, value_{std::in_place, std::forward<Args>(args)...} {}
+    : kd_key_{k}
+    , variant_{std::in_place, std::forward<Args>(args)...}
+#ifdef PH_TREE_ENTRY_POSTLEN
+    , postfix_len_{0}
+#endif
+    {
+    }
 
     [[nodiscard]] const KeyT& GetKey() const {
         return kd_key_;
     }
 
     [[nodiscard]] bool IsValue() const {
-        return value_.has_value();
+        return variant_.IsValue();
     }
 
     [[nodiscard]] bool IsNode() const {
-        return node_.get() != nullptr;
+        return variant_.IsNode();
     }
 
     [[nodiscard]] T& GetValue() const {
         assert(IsValue());
-        return const_cast<T&>(*value_);
+        return const_cast<T&>(variant_.GetValue());
     }
 
     [[nodiscard]] NodeT& GetNode() const {
         assert(IsNode());
-        return *node_;
+        return variant_.GetNode();
     }
 
     void SetNode(std::unique_ptr<NodeT>&& node) {
-        assert(!IsNode());
-        node_ = std::move(node);
-        value_.reset();
+#ifdef PH_TREE_ENTRY_POSTLEN
+        postfix_len_ = node->GetPostfixLen();
+#endif
+        variant_.SetNode(std::move(node));
+    }
+
+    [[nodiscard]] bit_width_t GetNodePostfixLen() const {
+        assert(IsNode());
+#ifdef PH_TREE_ENTRY_POSTLEN
+        return postfix_len_;
+#else
+        return variant_.GetNode().GetPostfixLen();
+#endif
     }
 
     [[nodiscard]] std::optional<ValueT>&& ExtractValue() {
         assert(IsValue());
-        return std::move(value_);
+        return variant_.ExtractValue();
     }
 
     [[nodiscard]] std::unique_ptr<NodeT>&& ExtractNode() {
         assert(IsNode());
-        return std::move(node_);
+        return variant_.ExtractNode();
     }
 
     void ReplaceNodeWithDataFromEntry(Entry&& other) {
         assert(IsNode());
         kd_key_ = other.GetKey();
-
-        if (other.IsNode()) {
-            node_ = std::move(other.node_);
-        } else {
-            value_ = std::move(other.value_);
-            node_.reset();
+        variant_ = std::move(other.variant_);
+#ifdef PH_TREE_ENTRY_POSTLEN
+        if (IsNode()) {
+            postfix_len_ = other.postfix_len_;
         }
+#endif
     }
 
   private:
     KeyT kd_key_;
-    std::unique_ptr<NodeT> node_;
-    std::optional<ValueT> value_;
+    EntryVariant<DIM, T, SCALAR> variant_;
+    // The length (number of bits) of post fixes (the part of the coordinate that is 'below' the
+    // current node). If a variable prefix_len would refer to the number of bits in this node's
+    // prefix, and if we assume 64 bit values, the following would always hold:
+    // prefix_len + 1 + postfix_len = 64.
+    // The '+1' accounts for the 1 bit that is represented by the local node's hypercube,
+    // i.e. the same bit that is used to create the lookup keys in entries_.
+#ifdef PH_TREE_ENTRY_POSTLEN
+    alignas(2) bit_width_t postfix_len_;
+#endif
 };
+
+//#pragma pack(push, 4)
+template <dimension_t DIM, typename T, typename SCALAR>
+struct EntryVariant {
+    using ValueT = std::remove_const_t<T>;
+    using NodeT = Node<DIM, T, SCALAR>;
+
+    enum {
+        VALUE = 0,
+        NODE = 1,
+        EMPTY = 2,
+    };
+
+    EntryVariant() = delete;
+
+    explicit EntryVariant(std::unique_ptr<NodeT>&& node_ptr)
+    : node_{std::move(node_ptr)}, type{NODE} {}
+
+    explicit EntryVariant(std::optional<ValueT>&& value) : value_{std::move(value)}, type{VALUE} {
+        assert(IsValue());
+        value.reset();  // TODO why???
+        assert(!value.has_value());
+    }
+
+    template <typename... Args>
+    explicit EntryVariant(std::in_place_t, Args&&... args)
+    : value_{std::in_place, std::forward<Args>(args)...}, type{VALUE} {
+        assert(IsValue());
+    }
+
+    EntryVariant(const EntryVariant& other) = delete;
+    EntryVariant& operator=(const EntryVariant& other) = delete;
+
+    EntryVariant(EntryVariant&& other) noexcept : type{std::move(other.type)} {
+        switch (type) {
+        case VALUE:
+            new (&value_) std::optional<ValueT>{std::move(other.value_)};
+            other.value_.reset();  // TODO why???
+            assert(!other.value_.has_value());
+            break;
+        case NODE:
+            new (&node_) std::unique_ptr<NodeT>{std::move(other.node_)};
+            break;
+        default:
+            assert(false);
+        }
+        other.type = EMPTY;
+        assert(type != EMPTY);
+    }
+
+    EntryVariant& operator=(EntryVariant&& other) noexcept {
+        switch (other.type) {
+        case VALUE:
+            if (IsNode()) {
+                auto node = std::move(node_);
+                new (&value_) std::optional<ValueT>{std::move(other.value_)};
+                other.value_.reset();  // TODO why???
+                // other.value_.~optional();
+                other.type = EMPTY;
+                assert(!other.value_.has_value());
+                node.~unique_ptr();
+            } else if (IsValue()) {
+                value_ = std::move(other.value_);
+            } else {
+                new (&value_) std::optional<ValueT>{std::move(other.value_)};
+                other.value_.reset();  // TODO why???
+                // other.value_.~optional();
+                assert(!other.value_.has_value());
+                other.type = EMPTY;
+            }
+            type = VALUE;
+            break;
+        case NODE:
+            if (IsNode()) {
+                auto node = std::move(node_);
+                node_ = std::move(other.node_);
+                //new (&node_) std::unique_ptr<NodeT>{std::move(other.node_)};
+                other.type = EMPTY;
+                node.~unique_ptr();
+            } else {
+                Destroy();
+                new (&node_) std::unique_ptr<NodeT>{std::move(other.node_)};
+                other.type = EMPTY;
+            }
+            type = NODE;
+            break;
+        default:
+            assert(false);
+        }
+        assert(type != EMPTY);
+        // other.type = EMPTY;
+        return *this;
+    }
+
+    ~EntryVariant() noexcept {
+        Destroy();
+    }
+
+    void Destroy() noexcept {
+        switch (type) {
+        case VALUE:
+            value_.~optional();
+            break;
+        case NODE:
+            node_.~unique_ptr();
+            break;
+        case EMPTY:
+            break;
+        default:
+            assert(false);
+        }
+        type = EMPTY;
+    }
+
+    void SetValue(std::optional<ValueT>&& value) noexcept {
+        Destroy();
+        type = VALUE;
+        new (&value_) std::optional<ValueT>{std::move(value)};
+        assert(!value);
+    }
+
+    void SetNode(std::unique_ptr<NodeT>&& node) noexcept {
+        Destroy();
+        type = NODE;
+        // move unique_ptr without calling destructor on previous value
+        new (&node_) std::unique_ptr<NodeT>{std::move(node)};
+        assert(!node);
+    }
+
+    [[nodiscard]] bool IsNode() const {
+        return type == NODE;
+    }
+
+    [[nodiscard]] bool IsValue() const {
+        return type == VALUE;
+    }
+
+    [[nodiscard]] NodeT& GetNode() const {
+        assert(type == NODE);
+        return *node_;
+    }
+
+    [[nodiscard]] T& GetValue() const {
+        assert(type == VALUE);
+        return const_cast<T&>(*value_);
+    }
+
+    [[nodiscard]] std::optional<ValueT>&& ExtractValue() {
+        assert(IsValue());
+        type = EMPTY;
+        return std::move(value_);
+    }
+
+    [[nodiscard]] std::unique_ptr<NodeT>&& ExtractNode() {
+        assert(IsNode());
+        type = EMPTY;
+        return std::move(node_);
+    }
+
+  private:
+    union {
+        std::unique_ptr<NodeT> node_;
+        std::optional<ValueT> value_;
+    };
+    alignas(2) std::uint16_t type;
+};
+//#pragma pack(pop)
+
 }  // namespace improbable::phtree::v16
 
 #endif  // PHTREE_V16_ENTRY_H


### PR DESCRIPTION
This implements issue #9 
It uses a `union` in `Entry` to store values and references to subnodes.
Due to values being represented by a std::optional, this union will rarely (if ever) reduce effective memory space.
However, it will free up some bytes that cane be used for other things, such as postfix/infix lengths, see issue #11.