### PR TITLE
Avoid std::uint16_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Potentially **BREAKING CHANGE** when using `IsNodeValid()` in provided filters:
+  Changed `bit_width_t` from `uin16_t` to `uint32_t`. This improves performance of 3D insert/emplace
+  on small datasets by up to 15%. To avoid warnings that meant that the API of `FilterAABB` and `FilterSphere` 
+  had to be changed to accept `uint32_t` instead of `int`. This may break some implementations.
 - DIM>8 now uses custom b_plus_tree_map instead of std::map. This improves performance for all operations, e.g.
   window queries on large datasets are up to 4x faster. Benchmarks results can be found in the issue. 
   [#14](https://github.com/tzaeschke/phtree-cpp/issues/14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Changed `bit_width_t` from `uin16_t` to `uint32_t`. This improves performance of 3D insert/emplace
   on small datasets by up to 15%. To avoid warnings that meant that the API of `FilterAABB` and `FilterSphere` 
   had to be changed to accept `uint32_t` instead of `int`. This may break some implementations.
+  [#17](https://github.com/tzaeschke/phtree-cpp/pull/17)
 - DIM>8 now uses custom b_plus_tree_map instead of std::map. This improves performance for all operations, e.g.
   window queries on large datasets are up to 4x faster. Benchmarks results can be found in the issue. 
   [#14](https://github.com/tzaeschke/phtree-cpp/issues/14)

--- a/phtree/common/base_types.h
+++ b/phtree/common/base_types.h
@@ -40,8 +40,10 @@ using scalar_64_t = int64_t;
 using scalar_32_t = int32_t;
 using scalar_16_t = int16_t;
 
-// Bits in a coordinate (usually a double or long has 64 bits, so uint_8 suffices)
-using bit_width_t = uint16_t;
+// Bits in a coordinate (usually a double or long has 64 bits, so uint_8 suffices).
+// However, uint32_t turned out to be faster, probably due to fewer cycles required for 32bit
+// instructions (8bit/16bit tend to require more cycles, see CPU tables available on the web).
+using bit_width_t = uint32_t;
 // Number of bit for 'scalar_64_t' or 'scalar_32_t'. Note that 'digits' does _not_ include sign bit,
 // so e.g. int64_t has 63 `digits`, however we need all bits, i.e. 64.
 template <typename SCALAR>

--- a/phtree/common/filter.h
+++ b/phtree/common/filter.h
@@ -126,7 +126,7 @@ class FilterAABB {
         return true;
     }
 
-    [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, int bits_to_ignore) const {
+    [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, std::uint32_t bits_to_ignore) const {
         // Let's assume that we always want to traverse the root node (bits_to_ignore == 64)
         if (bits_to_ignore >= (MAX_BIT_WIDTH<ScalarInternal> - 1)) {
             return true;
@@ -187,7 +187,7 @@ class FilterSphere {
      * Calculate whether AABB encompassing all possible points in the node intersects with the
      * sphere.
      */
-    [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, int bits_to_ignore) const {
+    [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, std::uint32_t bits_to_ignore) const {
         // we always want to traverse the root node (bits_to_ignore == 64)
 
         if (bits_to_ignore >= (MAX_BIT_WIDTH<ScalarInternal> - 1)) {

--- a/phtree/v16/entry.h
+++ b/phtree/v16/entry.h
@@ -55,13 +55,19 @@ class Entry {
      * Construct entry with existing node.
      */
     Entry(const KeyT& k, std::unique_ptr<NodeT>&& node_ptr, bit_width_t postfix_len) noexcept
-    : kd_key_{k}, node_{std::move(node_ptr)}, union_type_{NODE}, postfix_len_{postfix_len} {}
+    : kd_key_{k}
+    , node_{std::move(node_ptr)}
+    , union_type_{NODE}
+    , postfix_len_{static_cast<std::uint16_t>(postfix_len)} {}
 
     /*
      * Construct entry with a new node.
      */
     Entry(bit_width_t postfix_len) noexcept
-    : kd_key_(), node_{std::make_unique<NodeT>()}, union_type_{NODE}, postfix_len_{postfix_len} {}
+    : kd_key_()
+    , node_{std::make_unique<NodeT>()}
+    , union_type_{NODE}
+    , postfix_len_{static_cast<std::uint16_t>(postfix_len)} {}
 
     /*
      * Construct entry with existing T.
@@ -125,7 +131,7 @@ class Entry {
     }
 
     void SetNode(std::unique_ptr<NodeT>&& node, bit_width_t postfix_len) noexcept {
-        postfix_len_ = postfix_len;
+        postfix_len_ = static_cast<std::uint16_t>(postfix_len);
         DestroyUnion();
         union_type_ = NODE;
         new (&node_) std::unique_ptr<NodeT>{std::move(node)};
@@ -204,7 +210,7 @@ class Entry {
     // prefix_len + 1 + postfix_len = 64.
     // The '+1' accounts for the 1 bit that is represented by the local node's hypercube,
     // i.e. the same bit that is used to create the lookup keys in entries_.
-    alignas(2) bit_width_t postfix_len_;
+    alignas(2) std::uint16_t postfix_len_;
 };
 
 }  // namespace improbable::phtree::v16

--- a/phtree/v16/iterator_knn_hs.h
+++ b/phtree/v16/iterator_knn_hs.h
@@ -128,7 +128,7 @@ class IteratorKnnHS : public IteratorBase<T, CONVERT, FILTER> {
         current_distance_ = std::numeric_limits<double>::max();
     }
 
-    double DistanceToNode(const KeyInternal& prefix, int bits_to_ignore) {
+    double DistanceToNode(const KeyInternal& prefix, std::uint32_t bits_to_ignore) {
         assert(bits_to_ignore < MAX_BIT_WIDTH<SCALAR>);
         SCALAR mask_min = MAX_MASK<SCALAR> << bits_to_ignore;
         SCALAR mask_max = ~mask_min;
@@ -153,8 +153,8 @@ class IteratorKnnHS : public IteratorBase<T, CONVERT, FILTER> {
     double current_distance_;
     std::priority_queue<EntryDistT, std::vector<EntryDistT>, CompareEntryDistByDistance<EntryDistT>>
         queue_;
-    int num_found_results_;
-    int num_requested_results_;
+    size_t num_found_results_;
+    size_t num_requested_results_;
     DISTANCE distance_;
 };
 


### PR DESCRIPTION
This patch replaces the use of `std::uint16_t` with `std::uint32_t`. This increases performance of emplace/insert by up to 15%, see attached benchmark results.
The exact reason has not be determined but this is likely due to `std::uint16_t` tending to require more CPU cycles for math operations. It may also be related to less efficient optimization when using `std::uint16_t` types in the with vectorization.
[2022-04-avoid-uin16.txt](https://github.com/tzaeschke/phtree-cpp/files/8397514/2022-04-avoid-uin16.txt)
