### PR TITLE
Universal references for CALLBACK or FILTER API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Potentially **BREAKING CHANGE**: Refactored API of all methods that accept callbacks and filters to
+  accept universal/forwarding references.
+  Also changed filters and callback to not require `const` methods. 
+  [#22](https://github.com/tzaeschke/phtree-cpp/issues/22)
 - Clean up iterator implementations. [#19](https://github.com/tzaeschke/phtree-cpp/issues/19)
 - Make PhTree and PhTreeMultimap movable (move-assign/copy). [#18](https://github.com/tzaeschke/phtree-cpp/issues/18)
 - Potentially **BREAKING CHANGE** when using `IsNodeValid()` in provided filters:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,9 +42,9 @@ http_archive(
 http_archive(
     name = "gtest",
     build_file = "@third_party//gtest:BUILD",
-    sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
-    strip_prefix = "googletest-release-1.10.0",
-    url = "https://github.com/google/googletest/archive/release-1.10.0.tar.gz",
+    sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
+    strip_prefix = "googletest-release-1.11.0",
+    url = "https://github.com/google/googletest/archive/release-1.11.0.tar.gz",
 )
 
 # Development environment tooling

--- a/phtree/BUILD
+++ b/phtree/BUILD
@@ -109,6 +109,19 @@ cc_test(
 )
 
 cc_test(
+    name = "phtree_multimap_d_test_filter",
+    timeout = "long",
+    srcs = [
+        "phtree_multimap_d_test_filter.cc",
+    ],
+    linkstatic = True,
+    deps = [
+        ":phtree",
+        "//phtree/testing/gtest_main",
+    ],
+)
+
+cc_test(
     name = "phtree_d_test_custom_key",
     timeout = "long",
     srcs = [

--- a/phtree/phtree.h
+++ b/phtree/phtree.h
@@ -166,9 +166,9 @@ class PhTree {
      * sub-nodes before they are returned or traversed. Any filter function must follow the
      * signature of the default 'FilterNoOp`.
      */
-    template <typename CALLBACK_FN, typename FILTER = FilterNoOp>
-    void for_each(CALLBACK_FN& callback, FILTER filter = FILTER()) const {
-        tree_.for_each(callback, filter);
+    template <typename CALLBACK, typename FILTER = FilterNoOp>
+    void for_each(CALLBACK&& callback, FILTER&& filter = FILTER()) const {
+        tree_.for_each(std::forward<CALLBACK>(callback), std::forward<FILTER>(filter));
     }
 
     /*
@@ -183,15 +183,18 @@ class PhTree {
      * signature of the default 'FilterNoOp`.
      */
     template <
-        typename CALLBACK_FN,
+        typename CALLBACK,
         typename FILTER = FilterNoOp,
         typename QUERY_TYPE = DEFAULT_QUERY_TYPE>
     void for_each(
         QueryBox query_box,
-        CALLBACK_FN& callback,
-        FILTER filter = FILTER(),
+        CALLBACK&& callback,
+        FILTER&& filter = FILTER(),
         QUERY_TYPE query_type = QUERY_TYPE()) const {
-        tree_.for_each(query_type(converter_.pre_query(query_box)), callback, filter);
+        tree_.for_each(
+            query_type(converter_.pre_query(query_box)),
+            std::forward<CALLBACK>(callback),
+            std::forward<FILTER>(filter));
     }
 
     /*
@@ -202,8 +205,8 @@ class PhTree {
      * @return an iterator over all (filtered) entries in the tree,
      */
     template <typename FILTER = FilterNoOp>
-    auto begin(FILTER filter = FILTER()) const {
-        return tree_.begin(filter);
+    auto begin(FILTER&& filter = FILTER()) const {
+        return tree_.begin(std::forward<FILTER>(filter));
     }
 
     /*
@@ -219,9 +222,10 @@ class PhTree {
     template <typename FILTER = FilterNoOp, typename QUERY_TYPE = DEFAULT_QUERY_TYPE>
     auto begin_query(
         const QueryBox& query_box,
-        FILTER filter = FILTER(),
+        FILTER&& filter = FILTER(),
         QUERY_TYPE query_type = DEFAULT_QUERY_TYPE()) const {
-        return tree_.begin_query(query_type(converter_.pre_query(query_box)), filter);
+        return tree_.begin_query(
+            query_type(converter_.pre_query(query_box)), std::forward<FILTER>(filter));
     }
 
     /*
@@ -246,12 +250,15 @@ class PhTree {
     auto begin_knn_query(
         size_t min_results,
         const Key& center,
-        DISTANCE distance_function = DISTANCE(),
-        FILTER filter = FILTER()) const {
+        DISTANCE&& distance_function = DISTANCE(),
+        FILTER&& filter = FILTER()) const {
         // We use pre() instead of pre_query() here because, strictly speaking, we want to
         // find the nearest neighbors of a (fictional) key, which may as well be a box.
         return tree_.begin_knn_query(
-            min_results, converter_.pre(center), distance_function, filter);
+            min_results,
+            converter_.pre(center),
+            std::forward<DISTANCE>(distance_function),
+            std::forward<FILTER>(filter));
     }
 
     /*

--- a/phtree/phtree_multimap.h
+++ b/phtree/phtree_multimap.h
@@ -95,21 +95,19 @@ class IteratorBase {
     const T* current_value_ptr_;
 };
 
-template <typename ITERATOR_PH, typename PHTREE, typename FILTER>
+template <typename ITERATOR_PH, typename PHTREE>
 class IteratorNormal : public IteratorBase<PHTREE> {
     friend PHTREE;
     using BucketIterType = typename IteratorBase<PHTREE>::BucketIterType;
 
   public:
-    explicit IteratorNormal() noexcept
-    : IteratorBase<PHTREE>(), iter_ph_{}, iter_bucket_{}, filter_{} {}
+    explicit IteratorNormal() noexcept : IteratorBase<PHTREE>(), iter_ph_{}, iter_bucket_{} {}
 
-    template <typename ITER_PH, typename BucketIterType, typename FILTER2 = FILTER>
-    IteratorNormal(ITER_PH&& iter_ph, BucketIterType&& iter_bucket, FILTER2&& filter) noexcept
+    template <typename ITER_PH, typename BucketIterType>
+    IteratorNormal(ITER_PH&& iter_ph, BucketIterType&& iter_bucket) noexcept
     : IteratorBase<PHTREE>()
     , iter_ph_{std::forward<ITER_PH>(iter_ph)}
-    , iter_bucket_{std::forward<BucketIterType>(iter_bucket)}
-    , filter_{std::forward<FILTER2>(filter)} {
+    , iter_bucket_{std::forward<BucketIterType>(iter_bucket)} {
         FindNextElement();
     }
 
@@ -146,7 +144,8 @@ class IteratorNormal : public IteratorBase<PHTREE> {
         while (!iter_ph_.IsEnd()) {
             while (iter_bucket_ != iter_ph_->end()) {
                 // We filter only entries here, nodes are filtered elsewhere
-                if (filter_.IsEntryValid(iter_ph_.GetCurrentResult()->GetKey(), *iter_bucket_)) {
+                if (iter_ph_.__Filter().IsEntryValid(
+                        iter_ph_.GetCurrentResult()->GetKey(), *iter_bucket_)) {
                     this->SetCurrentValue(&(*iter_bucket_));
                     return;
                 }
@@ -163,16 +162,15 @@ class IteratorNormal : public IteratorBase<PHTREE> {
 
     ITERATOR_PH iter_ph_;
     BucketIterType iter_bucket_;
-    FILTER filter_;
 };
 
-template <typename ITERATOR_PH, typename PHTREE, typename FILTER>
-class IteratorKnn : public IteratorNormal<ITERATOR_PH, PHTREE, FILTER> {
+template <typename ITERATOR_PH, typename PHTREE>
+class IteratorKnn : public IteratorNormal<ITERATOR_PH, PHTREE> {
   public:
     template <typename BucketIterType>
-    IteratorKnn(ITERATOR_PH iter_ph, BucketIterType&& iter_bucket, const FILTER filter) noexcept
-    : IteratorNormal<ITERATOR_PH, PHTREE, FILTER>(
-          std::forward<ITERATOR_PH>(iter_ph), std::forward<BucketIterType>(iter_bucket), filter) {}
+    IteratorKnn(ITERATOR_PH iter_ph, BucketIterType&& iter_bucket) noexcept
+    : IteratorNormal<ITERATOR_PH, PHTREE>(
+          std::forward<ITERATOR_PH>(iter_ph), std::forward<BucketIterType>(iter_bucket)) {}
 
     [[nodiscard]] double distance() const noexcept {
         return this->GetIteratorOfPhTree().distance();
@@ -320,7 +318,7 @@ class PhTreeMultiMap {
     auto find(const Key& key) const {
         auto outer_iter = tree_.find(converter_.pre(key));
         if (outer_iter == tree_.end()) {
-            return CreateIterator(outer_iter, BucketIterType{});
+            return CreateIterator(outer_iter);
         }
         auto bucket_iter = outer_iter.second().begin();
         return CreateIterator(outer_iter, bucket_iter);
@@ -337,7 +335,7 @@ class PhTreeMultiMap {
     auto find(const Key& key, const T& value) const {
         auto outer_iter = tree_.find(converter_.pre(key));
         if (outer_iter == tree_.end()) {
-            return CreateIterator(outer_iter, BucketIterType{});
+            return CreateIterator(outer_iter);
         }
         auto bucket_iter = outer_iter.second().find(value);
         return CreateIterator(outer_iter, bucket_iter);
@@ -452,7 +450,7 @@ class PhTreeMultiMap {
 
     /*
      * Iterates over all entries in the tree. The optional filter allows filtering entries and nodes
-     * (=sub-trees) before returning / traversing them. By default all entries are returned. Filter
+     * (=sub-trees) before returning / traversing them. By default, all entries are returned. Filter
      * functions must implement the same signature as the default 'FilterNoOp'.
      *
      * @param callback The callback function to be called for every entry that matches the filter.
@@ -462,10 +460,12 @@ class PhTreeMultiMap {
      * follow the signature of the default 'FilterNoOp`.
      * The default 'FilterNoOp` filter matches all entries.
      */
-    template <typename CALLBACK_FN, typename FILTER = FilterNoOp>
-    void for_each(CALLBACK_FN& callback, FILTER filter = FILTER()) const {
-        CallbackWrapper<CALLBACK_FN, FILTER> inner_callback{callback, filter, converter_};
-        tree_.for_each(inner_callback, WrapFilter(filter));
+    template <typename CALLBACK, typename FILTER = FilterNoOp>
+    void for_each(CALLBACK&& callback, FILTER&& filter = FILTER()) const {
+        tree_.for_each(
+            NoOpCallback(),
+            WrapCallbackFilter<CALLBACK, FILTER>{
+                std::forward<CALLBACK>(callback), std::forward<FILTER>(filter), converter_});
     }
 
     /*
@@ -482,35 +482,37 @@ class PhTreeMultiMap {
      * The default 'FilterNoOp` filter matches all entries.
      */
     template <
-        typename CALLBACK_FN,
+        typename CALLBACK,
         typename FILTER = FilterNoOp,
         typename QUERY_TYPE = DEFAULT_QUERY_TYPE>
     void for_each(
         QueryBox query_box,
-        CALLBACK_FN& callback,
-        const FILTER& filter = FILTER(),
+        CALLBACK&& callback,
+        FILTER&& filter = FILTER(),
         QUERY_TYPE query_type = QUERY_TYPE()) const {
-        CallbackWrapper<CALLBACK_FN, FILTER> inner_callback{callback, filter, converter_};
         tree_.for_each(
-            query_type(converter_.pre_query(query_box)), inner_callback, WrapFilter(filter));
+            query_type(converter_.pre_query(query_box)),
+            NoOpCallback(),
+            WrapCallbackFilter<CALLBACK, FILTER>(
+                std::forward<CALLBACK>(callback), std::forward<FILTER>(filter), converter_));
     }
 
     /*
      * Iterates over all entries in the tree. The optional filter allows filtering entries and nodes
-     * (=sub-trees) before returning / traversing them. By default all entries are returned. Filter
+     * (=sub-trees) before returning / traversing them. By default, all entries are returned. Filter
      * functions must implement the same signature as the default 'FilterNoOp'.
      *
      * @return an iterator over all (filtered) entries in the tree,
      */
     template <typename FILTER = FilterNoOp>
-    auto begin(FILTER filter = FILTER()) const {
-        auto outer_iter = tree_.begin(WrapFilter(filter));
+    auto begin(FILTER&& filter = FILTER()) const {
+        auto outer_iter = tree_.begin(WrapFilter(std::forward<FILTER>(filter)));
         if (outer_iter == tree_.end()) {
-            return CreateIterator(outer_iter, BucketIterType{}, filter);
+            return CreateIterator(outer_iter);
         }
         auto bucket_iter = outer_iter.second().begin();
         assert(bucket_iter != outer_iter.second().end());
-        return CreateIterator(outer_iter, bucket_iter, filter);
+        return CreateIterator(outer_iter, bucket_iter);
     }
 
     /*
@@ -526,16 +528,16 @@ class PhTreeMultiMap {
     template <typename FILTER = FilterNoOp, typename QUERY_TYPE = DEFAULT_QUERY_TYPE>
     auto begin_query(
         const QueryBox& query_box,
-        FILTER filter = FILTER(),
+        FILTER&& filter = FILTER(),
         QUERY_TYPE query_type = QUERY_TYPE()) const {
-        auto outer_iter =
-            tree_.begin_query(query_type(converter_.pre_query(query_box)), WrapFilter(filter));
+        auto outer_iter = tree_.begin_query(
+            query_type(converter_.pre_query(query_box)), WrapFilter(std::forward<FILTER>(filter)));
         if (outer_iter == tree_.end()) {
-            return CreateIterator(outer_iter, BucketIterType{}, filter);
+            return CreateIterator(outer_iter, BucketIterType{});
         }
         auto bucket_iter = outer_iter.second().begin();
         assert(bucket_iter != outer_iter.second().end());
-        return CreateIterator(outer_iter, bucket_iter, filter);
+        return CreateIterator(outer_iter, bucket_iter);
     }
 
     /*
@@ -560,25 +562,28 @@ class PhTreeMultiMap {
     auto begin_knn_query(
         size_t min_results,
         const Key& center,
-        DISTANCE distance_function = DISTANCE(),
-        FILTER filter = FILTER()) const {
+        DISTANCE&& distance_function = DISTANCE(),
+        FILTER&& filter = FILTER()) const {
         // We use pre() instead of pre_query() here because, strictly speaking, we want to
         // find the nearest neighbors of a (fictional) key, which may as well be a box.
         auto outer_iter = tree_.begin_knn_query(
-            min_results, converter_.pre(center), distance_function, WrapFilter(filter));
+            min_results,
+            converter_.pre(center),
+            std::forward<DISTANCE>(distance_function),
+            WrapFilter(std::forward<FILTER>(filter)));
         if (outer_iter == tree_.end()) {
-            return CreateIteratorKnn(outer_iter, BucketIterType{}, filter);
+            return CreateIteratorKnn(outer_iter);
         }
         auto bucket_iter = outer_iter.second().begin();
         assert(bucket_iter != outer_iter.second().end());
-        return CreateIteratorKnn(outer_iter, bucket_iter, filter);
+        return CreateIteratorKnn(outer_iter, bucket_iter);
     }
 
     /*
      * @return An iterator representing the tree's 'end'.
      */
     auto end() const {
-        return IteratorNormal<EndType, PHTREE, FilterNoOp>{};
+        return IteratorNormal<EndType, PHTREE>{};
     }
 
     /*
@@ -616,62 +621,88 @@ class PhTreeMultiMap {
         return tree_;
     }
 
-    template <typename OUTER_ITER, typename INNER_ITER, typename FILTER = FilterNoOp>
-    auto CreateIterator(
-        OUTER_ITER outer_iter, INNER_ITER&& bucket_iter, FILTER&& filter = FILTER()) const {
-        return IteratorNormal<OUTER_ITER, PHTREE, FILTER>(
-            std::forward<OUTER_ITER>(outer_iter),
-            std::forward<INNER_ITER>(bucket_iter),
-            std::forward<FILTER>(filter));
+    template <typename OUTER_ITER, typename INNER_ITER = BucketIterType>
+    auto CreateIterator(OUTER_ITER outer_iter, INNER_ITER&& bucket_iter = INNER_ITER{}) const {
+        return IteratorNormal<OUTER_ITER, PHTREE>(
+            std::forward<OUTER_ITER>(outer_iter), std::forward<INNER_ITER>(bucket_iter));
     }
 
-    template <typename OUTER_ITER, typename INNER_ITER, typename FILTER = FilterNoOp>
-    auto CreateIteratorKnn(
-        OUTER_ITER outer_iter, INNER_ITER&& bucket_iter, FILTER&& filter = FILTER()) const {
-        return IteratorKnn<OUTER_ITER, PHTREE, FILTER>(
-            std::forward<OUTER_ITER>(outer_iter),
-            std::forward<INNER_ITER>(bucket_iter),
-            std::forward<FILTER>(filter));
+    template <typename OUTER_ITER, typename INNER_ITER = BucketIterType>
+    auto CreateIteratorKnn(OUTER_ITER outer_iter, INNER_ITER&& bucket_iter = INNER_ITER{}) const {
+        return IteratorKnn<OUTER_ITER, PHTREE>(
+            std::forward<OUTER_ITER>(outer_iter), std::forward<INNER_ITER>(bucket_iter));
     }
 
+    /*
+     * We have two iterators, one that traverses the PH-Tree and one that traverses the
+     * bucket. We need two IsEntryValid() for these two iterators.
+     * The IsEntryValid() for the PH-Tree iterator always returns true (we do not support
+     * checking buckets at the moment).
+     * The IsEntryValid() for the bucket iterator forwards the call to the user defined
+     * IsEntryValid() for every entry in the bucket.
+     */
     template <typename FILTER>
-    static auto WrapFilter(FILTER filter) {
+    static auto WrapFilter(FILTER&& filter) {
+        struct FilterWrapper {
+            [[nodiscard]] constexpr bool IsEntryValid(const KeyInternal&, const BUCKET&) {
+                // This filter is used in the PH-Tree iterator.
+                return true;
+            }
+            [[nodiscard]] constexpr bool IsEntryValid(const KeyInternal& key, const T& value) {
+                // This filter is used in the PH-Tree multimap iterator (bucket iterator).
+                return filter_.IsEntryValid(key, value);
+            }
+            [[nodiscard]] constexpr bool IsNodeValid(
+                const KeyInternal& prefix, int bits_to_ignore) {
+                return filter_.IsNodeValid(prefix, bits_to_ignore);
+            }
+            FILTER filter_;
+        };
+        return FilterWrapper{std::forward<FILTER>(filter)};
+    }
+
+    /*
+     * This wrapper wraps the Filter and Callback such that the callback is called for every
+     * bucket entry that matches the user defined IsEntryValid().
+     */
+    template <typename CALLBACK, typename FILTER>
+    class WrapCallbackFilter {
+      public:
         // We always have two iterators, one that traverses the PH-Tree and one that traverses the
         // bucket. Using the FilterWrapper we create a new Filter for the PH-Tree iterator. This new
         // filter checks only if nodes are valid. It cannot check whether buckets are valid.
         // The original filter is then used when we iterate over the entries of a bucket. At this
         // point, we do not need to check IsNodeValid anymore for each entry (see `IteratorNormal`).
-        struct FilterWrapper {
-            [[nodiscard]] constexpr bool IsEntryValid(const KeyInternal&, const BUCKET&) const {
-                // This filter is checked in the Iterator.
-                return true;
-            }
-            [[nodiscard]] constexpr bool IsNodeValid(
-                const KeyInternal& prefix, int bits_to_ignore) const {
-                return filter_.IsNodeValid(prefix, bits_to_ignore);
-            }
-            FILTER filter_;
-        };
-        return FilterWrapper{filter};
-    }
+        template <typename CB, typename F>
+        WrapCallbackFilter(CB&& callback, F&& filter, const CONVERTER& converter)
+        : callback_{std::forward<CB>(callback)}
+        , filter_{std::forward<F>(filter)}
+        , converter_{converter} {}
 
-    template <typename CALLBACK_FN, typename FILTER>
-    struct CallbackWrapper {
-        /*
-         * The CallbackWrapper ensures that we call the callback on each entry of the bucket.
-         * The vanilla PH-Tree call it only on the bucket itself.
-         */
-        void operator()(const Key& key, const BUCKET& bucket) const {
-            auto internal_key = converter_.pre(key);
+        [[nodiscard]] constexpr bool IsEntryValid(
+            const KeyInternal& internal_key, const BUCKET& bucket) {
+            auto key = converter_.post(internal_key);
             for (auto& entry : bucket) {
                 if (filter_.IsEntryValid(internal_key, entry)) {
                     callback_(key, entry);
                 }
             }
+            // Return false. We already called the callback.
+            return false;
         }
-        CALLBACK_FN& callback_;
-        const FILTER filter_;
+
+        [[nodiscard]] constexpr bool IsNodeValid(const KeyInternal& prefix, int bits_to_ignore) {
+            return filter_.IsNodeValid(prefix, bits_to_ignore);
+        }
+
+      private:
+        CALLBACK callback_;
+        FILTER filter_;
         const CONVERTER& converter_;
+    };
+
+    struct NoOpCallback {
+        void operator()(const Key&, const BUCKET&) {}
     };
 
     v16::PhTreeV16<DimInternal, BUCKET, CONVERTER> tree_;

--- a/phtree/phtree_multimap_d_test.cc
+++ b/phtree/phtree_multimap_d_test.cc
@@ -1184,7 +1184,7 @@ TEST(PhTreeTest, TestMovableIterators) {
     tree.emplace(p, Id{1});
 
     ASSERT_TRUE(std::is_move_constructible_v<decltype(tree.begin())>);
-    // ASSERT_TRUE(std::is_move_assignable_v<decltype(tree.begin())>);
+    ASSERT_TRUE(std::is_move_assignable_v<decltype(tree.begin())>);
     ASSERT_NE(tree.begin(), tree.end());
 
     ASSERT_TRUE(std::is_move_constructible_v<decltype(tree.end())>);

--- a/phtree/phtree_multimap_d_test_filter.cc
+++ b/phtree/phtree_multimap_d_test_filter.cc
@@ -14,18 +14,23 @@
  * limitations under the License.
  */
 
-#include "phtree/phtree.h"
+#include "phtree/phtree_multimap.h"
 #include <gtest/gtest.h>
 #include <random>
 #include <unordered_set>
 
 using namespace improbable::phtree;
 
+// Number of entries that have the same coordinate
+static const size_t NUM_DUPL = 4;
+[[maybe_unused]] static const double WORLD_MIN = -1000;
+[[maybe_unused]] static const double WORLD_MAX = 1000;
+
 template <dimension_t DIM>
 using TestPoint = PhPointD<DIM>;
 
 template <dimension_t DIM, typename T>
-using TestTree = PhTreeD<DIM, T>;
+using TestTree = PhTreeMultiMap<DIM, T, ConverterIEEE<DIM>>;
 
 class DoubleRng {
   public:
@@ -57,23 +62,47 @@ struct Id {
     int _i;
 };
 
+namespace std {
+template <>
+struct hash<Id> {
+    size_t operator()(const Id& x) const {
+        return std::hash<int>{}(x._i);
+    }
+};
+};  // namespace std
+
+struct IdHash {
+    template <class T1, class T2>
+    std::size_t operator()(std::pair<T1, T2> const& v) const {
+        return std::hash<T1>()(v.size());
+    }
+};
+
 template <dimension_t DIM>
 void generateCube(std::vector<TestPoint<DIM>>& points, size_t N) {
-    DoubleRng rng(-1000, 1000);
-    auto refTree = std::map<TestPoint<DIM>, size_t>();
+    assert(N % NUM_DUPL == 0);
+    DoubleRng rng(WORLD_MIN, WORLD_MAX);
+    auto reference_set = std::unordered_map<TestPoint<DIM>, size_t>();
 
     points.reserve(N);
-    for (size_t i = 0; i < N; i++) {
-        auto point = TestPoint<DIM>{rng.next(), rng.next(), rng.next()};
-        if (refTree.count(point) != 0) {
+    for (size_t i = 0; i < N / NUM_DUPL; i++) {
+        // create duplicates, ie. entries with the same coordinates. However, avoid unintentional
+        // duplicates.
+        TestPoint<DIM> key{};
+        for (dimension_t d = 0; d < DIM; ++d) {
+            key[d] = rng.next();
+        }
+        if (reference_set.count(key) != 0) {
             i--;
             continue;
         }
-
-        refTree.emplace(point, i);
-        points.push_back(point);
+        reference_set.emplace(key, i);
+        for (size_t dupl = 0; dupl < NUM_DUPL; dupl++) {
+            auto point = TestPoint<DIM>(key);
+            points.push_back(point);
+        }
     }
-    ASSERT_EQ(refTree.size(), N);
+    ASSERT_EQ(reference_set.size(), N / NUM_DUPL);
     ASSERT_EQ(points.size(), N);
 }
 
@@ -217,7 +246,7 @@ struct CallbackCount {
         ++f_destruct_;
     }
 
-    void operator()(TestPoint<DIM>, Id& t) {
+    void operator()(const TestPoint<DIM>, const Id& t) {
         static_id = t._i;
     }
 };
@@ -240,7 +269,7 @@ struct CallbackConst {
     }
 };
 
-static void print_id_counters() {
+[[maybe_unused]] static void print_id_counters() {
     std::cout << "dc=" << f_default_construct_ << " c=" << f_construct_
               << " cc=" << f_copy_construct_ << " mc=" << f_move_construct_
               << " ca=" << f_copy_assign_ << " ma=" << f_move_assign_ << " d=" << f_destruct_

--- a/phtree/phtree_test.cc
+++ b/phtree/phtree_test.cc
@@ -95,12 +95,10 @@ struct Id {
     }
 
     bool operator==(const Id& rhs) const {
-        ++copy_assign_count_;
         return _i == rhs._i;
     }
 
     bool operator==(Id&& rhs) const {
-        ++move_assign_count_;
         return _i == rhs._i;
     }
 

--- a/phtree/v16/for_each.h
+++ b/phtree/v16/for_each.h
@@ -26,7 +26,7 @@ namespace improbable::phtree::v16 {
  * Iterates over the whole tree. Entries and child nodes that are rejected by the Filter are not
  * traversed or returned.
  */
-template <typename T, typename CONVERT, typename CALLBACK_FN, typename FILTER>
+template <typename T, typename CONVERT, typename CALLBACK, typename FILTER>
 class ForEach {
     static constexpr dimension_t DIM = CONVERT::DimInternal;
     using KeyInternal = typename CONVERT::KeyInternal;
@@ -34,8 +34,11 @@ class ForEach {
     using EntryT = Entry<DIM, T, SCALAR>;
 
   public:
-    ForEach(const CONVERT* converter, CALLBACK_FN& callback, FILTER filter)
-    : converter_{converter}, callback_{callback}, filter_(std::move(filter)) {}
+    template <typename CB, typename F>
+    ForEach(const CONVERT* converter, CB&& callback, F&& filter)
+    : converter_{converter}
+    , callback_{std::forward<CB>(callback)}
+    , filter_(std::forward<F>(filter)) {}
 
     void Traverse(const EntryT& entry) {
         assert(entry.IsNode());
@@ -59,7 +62,7 @@ class ForEach {
     }
 
     const CONVERT* converter_;
-    CALLBACK_FN& callback_;
+    CALLBACK callback_;
     FILTER filter_;
 };
 }  // namespace improbable::phtree::v16

--- a/phtree/v16/for_each_hc.h
+++ b/phtree/v16/for_each_hc.h
@@ -33,7 +33,7 @@ namespace improbable::phtree::v16 {
  * For details see  "Efficient Z-Ordered Traversal of Hypercube Indexes" by T. Zäschke, M.C. Norrie,
  * 2017.
  */
-template <typename T, typename CONVERT, typename CALLBACK_FN, typename FILTER>
+template <typename T, typename CONVERT, typename CALLBACK, typename FILTER>
 class ForEachHC {
     static constexpr dimension_t DIM = CONVERT::DimInternal;
     using KeyInternal = typename CONVERT::KeyInternal;
@@ -41,17 +41,18 @@ class ForEachHC {
     using EntryT = Entry<DIM, T, SCALAR>;
 
   public:
+    template <typename CB, typename F>
     ForEachHC(
         const KeyInternal& range_min,
         const KeyInternal& range_max,
         const CONVERT* converter,
-        CALLBACK_FN& callback,
-        FILTER filter)
+        CB&& callback,
+        F&& filter)
     : range_min_{range_min}
     , range_max_{range_max}
     , converter_{converter}
-    , callback_{callback}
-    , filter_(std::move(filter)) {}
+    , callback_{std::forward<CB>(callback)}
+    , filter_(std::forward<F>(filter)) {}
 
     void Traverse(const EntryT& entry) {
         assert(entry.IsNode());
@@ -84,7 +85,7 @@ class ForEachHC {
         }
     }
 
-    bool CheckNode(const EntryT& entry, bit_width_t parent_postfix_len) const {
+    bool CheckNode(const EntryT& entry, bit_width_t parent_postfix_len) {
         const KeyInternal& key = entry.GetKey();
         // Check if the node overlaps with the query box.
         // An infix with len=0 implies that at least part of the child node overlaps with the query,
@@ -169,7 +170,7 @@ class ForEachHC {
     const KeyInternal range_min_;
     const KeyInternal range_max_;
     const CONVERT* converter_;
-    CALLBACK_FN& callback_;
+    CALLBACK callback_;
     FILTER filter_;
 };
 }  // namespace improbable::phtree::v16

--- a/phtree/v16/iterator_base.h
+++ b/phtree/v16/iterator_base.h
@@ -92,8 +92,9 @@ class IteratorWithFilter
     using EntryT = Entry<DIM, T, SCALAR>;
 
   public:
-    explicit IteratorWithFilter(const CONVERT* converter, FILTER filter) noexcept
-    : IteratorBase<EntryT>(nullptr), converter_{converter}, filter_(std::forward<FILTER>(filter)) {}
+    template <typename F>
+    explicit IteratorWithFilter(const CONVERT* converter, F&& filter) noexcept
+    : IteratorBase<EntryT>(nullptr), converter_{converter}, filter_(std::forward<F>(filter)) {}
 
     explicit IteratorWithFilter(const EntryT* current_result, const CONVERT* converter) noexcept
     : IteratorBase<EntryT>(current_result), converter_{converter}, filter_{FILTER()} {}
@@ -102,8 +103,12 @@ class IteratorWithFilter
         return converter_->post(this->current_result_->GetKey());
     }
 
+    auto& __Filter() {
+        return filter_;
+    }
+
   protected:
-    [[nodiscard]] bool ApplyFilter(const EntryT& entry) const {
+    [[nodiscard]] bool ApplyFilter(const EntryT& entry) {
         return entry.IsNode() ? filter_.IsNodeValid(entry.GetKey(), entry.GetNodePostfixLen() + 1)
                               : filter_.IsEntryValid(entry.GetKey(), entry.GetValue());
     }

--- a/phtree/v16/iterator_full.h
+++ b/phtree/v16/iterator_full.h
@@ -33,8 +33,11 @@ class IteratorFull : public IteratorWithFilter<T, CONVERT, FILTER> {
     using EntryT = typename IteratorWithFilter<T, CONVERT, FILTER>::EntryT;
 
   public:
-    IteratorFull(const EntryT& root, const CONVERT* converter, FILTER filter)
-    : IteratorWithFilter<T, CONVERT, FILTER>(converter, filter), stack_{}, stack_size_{0} {
+    template <typename F>
+    IteratorFull(const EntryT& root, const CONVERT* converter, F&& filter)
+    : IteratorWithFilter<T, CONVERT, F>(converter, std::forward<F>(filter))
+    , stack_{}
+    , stack_size_{0} {
         PrepareAndPush(root.GetNode());
         FindNextElement();
     }

--- a/phtree/v16/iterator_hc.h
+++ b/phtree/v16/iterator_hc.h
@@ -49,13 +49,14 @@ class IteratorHC : public IteratorWithFilter<T, CONVERT, FILTER> {
     using EntryT = typename IteratorWithFilter<T, CONVERT, FILTER>::EntryT;
 
   public:
+    template <typename F>
     IteratorHC(
         const EntryT& root,
         const KeyInternal& range_min,
         const KeyInternal& range_max,
         const CONVERT* converter,
-        FILTER filter)
-    : IteratorWithFilter<T, CONVERT, FILTER>(converter, filter)
+        F&& filter)
+    : IteratorWithFilter<T, CONVERT, F>(converter, std::forward<F>(filter))
     , stack_size_{0}
     , range_min_{range_min}
     , range_max_{range_max} {

--- a/phtree/v16/iterator_knn_hs.h
+++ b/phtree/v16/iterator_knn_hs.h
@@ -53,20 +53,21 @@ class IteratorKnnHS : public IteratorWithFilter<T, CONVERT, FILTER> {
     using EntryDistT = EntryDist<DIM, T, SCALAR>;
 
   public:
+    template <typename DIST, typename F>
     explicit IteratorKnnHS(
         const EntryT& root,
         size_t min_results,
         const KeyInternal& center,
         const CONVERT* converter,
-        DISTANCE dist,
-        FILTER filter)
-    : IteratorWithFilter<T, CONVERT, FILTER>(converter, filter)
+        DIST&& dist,
+        F&& filter)
+    : IteratorWithFilter<T, CONVERT, F>(converter, std::forward<F>(filter))
     , center_{center}
     , center_post_{converter->post(center)}
     , current_distance_{std::numeric_limits<double>::max()}
     , num_found_results_(0)
     , num_requested_results_(min_results)
-    , distance_(std::move(dist)) {
+    , distance_(std::forward<DIST>(dist)) {
         if (min_results <= 0 || root.GetNode().GetEntryCount() == 0) {
             this->SetFinished();
             return;


### PR DESCRIPTION
Adapt API methods that accept CALLBACK or FILTER to use universal/forwarding references.
See issue #22 