### PR TITLE
Fix/26 filter multimap breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Nothing yet
+- **API BREAKING CHANGE**: Allow filtering on buckets in multimaps. Multimap filters have different functions
+  and function signatures than normal `PhTree` filters. [#26](https://github.com/tzaeschke/phtree-cpp/issues/26)
 
 ## [1.2.0] - 2022-04-14
 ### Changed

--- a/phtree/benchmark/BUILD
+++ b/phtree/benchmark/BUILD
@@ -231,6 +231,21 @@ cc_binary(
 )
 
 cc_binary(
+    name = "query_mm_d_filter_benchmark",
+    testonly = True,
+    srcs = [
+        "query_mm_d_filter_benchmark.cc",
+    ],
+    linkstatic = True,
+    deps = [
+        "//phtree",
+        "//phtree/benchmark",
+        "@gbenchmark//:benchmark",
+        "@spdlog",
+    ],
+)
+
+cc_binary(
     name = "query_mm_box_d_benchmark",
     testonly = True,
     srcs = [

--- a/phtree/benchmark/query_mm_d_filter_benchmark.cc
+++ b/phtree/benchmark/query_mm_d_filter_benchmark.cc
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2020 Improbable Worlds Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "benchmark_util.h"
+#include "logging.h"
+#include "phtree/phtree.h"
+#include "phtree/phtree_multimap.h"
+#include <benchmark/benchmark.h>
+#include <random>
+
+using namespace improbable;
+using namespace improbable::phtree;
+using namespace improbable::phtree::phbenchmark;
+
+/*
+ * Benchmark for querying entries in multi-map implementations.
+ * This benchmarks uses a SPHERE shaped query!
+ */
+namespace {
+
+const double GLOBAL_MAX = 10000;
+
+enum Scenario { SPHERE_WQ, SPHERE, WQ, LEGACY_WQ };
+
+using TestPoint = PhPointD<3>;
+using QueryBox = PhBoxD<3>;
+using payload_t = TestPoint;
+using BucketType = std::set<payload_t>;
+
+struct Query {
+    QueryBox box{};
+    TestPoint center{};
+    double radius{};
+};
+
+template <dimension_t DIM>
+using CONVERTER = ConverterIEEE<DIM>;
+
+template <dimension_t DIM>
+using DistanceFn = DistanceEuclidean<DIM>;
+
+template <dimension_t DIM>
+using TestMap = PhTreeMultiMapD<DIM, payload_t, CONVERTER<DIM>>;
+
+template <dimension_t DIM, Scenario SCENARIO>
+class IndexBenchmark {
+  public:
+    IndexBenchmark(benchmark::State& state, double avg_query_result_size_);
+
+    void Benchmark(benchmark::State& state);
+
+  private:
+    void SetupWorld(benchmark::State& state);
+    void QueryWorld(benchmark::State& state, const Query& query);
+    void CreateQuery(Query& query);
+
+    const TestGenerator data_type_;
+    const size_t num_entities_;
+    const double avg_query_result_size_;
+
+    constexpr double query_endge_length() {
+        return GLOBAL_MAX * pow(avg_query_result_size_ / (double)num_entities_, 1. / (double)DIM);
+    };
+
+    TestMap<DIM> tree_;
+    std::default_random_engine random_engine_;
+    std::uniform_real_distribution<> cube_distribution_;
+    std::vector<PhPointD<DIM>> points_;
+};
+
+template <dimension_t DIM, Scenario SCENARIO>
+IndexBenchmark<DIM, SCENARIO>::IndexBenchmark(benchmark::State& state, double avg_query_result_size)
+: data_type_{static_cast<TestGenerator>(state.range(1))}
+, num_entities_(state.range(0))
+, avg_query_result_size_(avg_query_result_size)
+, tree_{}
+, random_engine_{1}
+, cube_distribution_{0, GLOBAL_MAX}
+, points_(num_entities_) {
+    logging::SetupDefaultLogging();
+    SetupWorld(state);
+}
+
+template <dimension_t DIM, Scenario SCENARIO>
+void IndexBenchmark<DIM, SCENARIO>::Benchmark(benchmark::State& state) {
+    Query query{};
+    for (auto _ : state) {
+        state.PauseTiming();
+        CreateQuery(query);
+        state.ResumeTiming();
+
+        QueryWorld(state, query);
+    }
+}
+
+template <dimension_t DIM>
+void InsertEntry(TestMap<DIM>& tree, const PhPointD<DIM>& point, const payload_t& data) {
+    tree.emplace(point, data);
+}
+
+bool CheckPosition(const payload_t& entity, const TestPoint& center, double radius) {
+    const auto& point = entity;
+    double dx = center[0] - point[0];
+    double dy = center[1] - point[1];
+    double dz = center[2] - point[2];
+    return dx * dx + dy * dy + dz * dz <= radius * radius;
+}
+
+struct CounterCheckPosition {
+    template <typename T>
+    void operator()(const PhPointD<3>& p, const T&) {
+        n_ += CheckPosition(p, center_, radius_);
+    }
+    const TestPoint& center_;
+    double radius_;
+    size_t n_;
+};
+
+struct Counter {
+    void operator()(const PhPointD<3>&, const payload_t&) {
+        ++n_;
+    }
+    size_t n_;
+};
+
+template <dimension_t DIM, Scenario SCENARIO>
+typename std::enable_if<SCENARIO == Scenario::SPHERE_WQ, int>::type CountEntries(
+    TestMap<DIM>& tree, const Query& query) {
+    FilterMultiMapSphere filter{query.center, query.radius, tree.converter(), DistanceFn<DIM>()};
+    Counter counter{0};
+    tree.for_each(query.box, counter, filter);
+    return counter.n_;
+}
+
+template <dimension_t DIM, Scenario SCENARIO>
+typename std::enable_if<SCENARIO == Scenario::SPHERE, int>::type CountEntries(
+    TestMap<DIM>& tree, const Query& query) {
+    FilterMultiMapSphere filter{query.center, query.radius, tree.converter(), DistanceFn<DIM>()};
+    Counter counter{0};
+    tree.for_each(counter, filter);
+    return counter.n_;
+}
+
+template <dimension_t DIM, Scenario SCENARIO>
+typename std::enable_if<SCENARIO == Scenario::WQ, int>::type CountEntries(
+    TestMap<DIM>& tree, const Query& query) {
+    CounterCheckPosition counter{query.center, query.radius, 0};
+    tree.for_each(query.box, counter);
+    return counter.n_;
+}
+
+template <dimension_t DIM, Scenario SCENARIO>
+typename std::enable_if<SCENARIO == Scenario::LEGACY_WQ, int>::type CountEntries(
+    TestMap<DIM>& tree, const Query& query) {
+    // Legacy: use non-multi-map filter
+    FilterSphere filter{query.center, query.radius, tree.converter(), DistanceFn<DIM>()};
+    Counter counter{0};
+    tree.for_each(query.box, counter, filter);
+    return counter.n_;
+}
+
+template <dimension_t DIM, Scenario SCENARIO>
+void IndexBenchmark<DIM, SCENARIO>::SetupWorld(benchmark::State& state) {
+    logging::info("Setting up world with {} entities and {} dimensions.", num_entities_, DIM);
+    // create data with about 10% duplicate coordinates
+    CreatePointData<DIM>(points_, data_type_, num_entities_, 0, GLOBAL_MAX, 0.8);
+    for (size_t i = 0; i < num_entities_; ++i) {
+        InsertEntry(tree_, points_[i], points_[i]);
+    }
+
+    state.counters["query_rate"] = benchmark::Counter(0, benchmark::Counter::kIsRate);
+    state.counters["result_rate"] = benchmark::Counter(0, benchmark::Counter::kIsRate);
+    state.counters["avg_result_count"] = benchmark::Counter(0, benchmark::Counter::kAvgIterations);
+    logging::info("World setup complete.");
+}
+
+template <dimension_t DIM, Scenario SCENARIO>
+void IndexBenchmark<DIM, SCENARIO>::QueryWorld(benchmark::State& state, const Query& query) {
+    int n = CountEntries<DIM, SCENARIO>(tree_, query);
+
+    state.counters["query_rate"] += 1;
+    state.counters["result_rate"] += n;
+    state.counters["avg_result_count"] += n;
+}
+
+template <dimension_t DIM, Scenario SCENARIO>
+void IndexBenchmark<DIM, SCENARIO>::CreateQuery(Query& query) {
+    double radius = query_endge_length() * 0.5;
+    for (dimension_t d = 0; d < DIM; ++d) {
+        auto x = cube_distribution_(random_engine_);
+        query.box.min()[d] = x - radius;
+        query.box.max()[d] = x + radius;
+        query.center[d] = x;
+    }
+    query.radius = radius;
+}
+
+}  // namespace
+
+template <typename... Arguments>
+void PhTree3DSphereWQ(benchmark::State& state, Arguments&&... arguments) {
+    IndexBenchmark<3, Scenario::SPHERE_WQ> benchmark{state, arguments...};
+    benchmark.Benchmark(state);
+}
+
+template <typename... Arguments>
+void PhTree3DSphere(benchmark::State& state, Arguments&&... arguments) {
+    IndexBenchmark<3, Scenario::SPHERE> benchmark{state, arguments...};
+    benchmark.Benchmark(state);
+}
+
+template <typename... Arguments>
+void PhTree3DWQ(benchmark::State& state, Arguments&&... arguments) {
+    IndexBenchmark<3, Scenario::WQ> benchmark{state, arguments...};
+    benchmark.Benchmark(state);
+}
+
+template <typename... Arguments>
+void PhTree3DLegacyWQ(benchmark::State& state, Arguments&&... arguments) {
+    IndexBenchmark<3, Scenario::LEGACY_WQ> benchmark{state, arguments...};
+    benchmark.Benchmark(state);
+}
+
+// index type, scenario name, data_type, num_entities, avg_query_result_size
+BENCHMARK_CAPTURE(PhTree3DSphereWQ, WQ_100, 100.0)
+    ->RangeMultiplier(10)
+    ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(PhTree3DSphere, WQ_100, 100.0)
+    ->RangeMultiplier(10)
+    ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(PhTree3DWQ, WQ_100, 100.0)
+    ->RangeMultiplier(10)
+    ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(PhTree3DLegacyWQ, WQ_100, 100.0)
+    ->RangeMultiplier(10)
+    ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_MAIN();

--- a/phtree/benchmark/query_mm_d_filter_benchmark.cc
+++ b/phtree/benchmark/query_mm_d_filter_benchmark.cc
@@ -322,11 +322,6 @@ void PhTree3DLegacyWQ(benchmark::State& state, Arguments&&... arguments) {
 }
 
 // index type, scenario name, data_type, num_entities, avg_query_result_size
-BENCHMARK_CAPTURE(PhTree3DSphereITWQ, _100, 100.0)
-    ->RangeMultiplier(10)
-    ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
-    ->Unit(benchmark::kMillisecond);
-
 BENCHMARK_CAPTURE(PhTree3DSphereWQ, _100, 100.0)
     ->RangeMultiplier(10)
     ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
@@ -338,6 +333,11 @@ BENCHMARK_CAPTURE(PhTree3DSphere, _100, 100.0)
     ->Unit(benchmark::kMillisecond);
 
 BENCHMARK_CAPTURE(PhTree3DWQ, _100, 100.0)
+    ->RangeMultiplier(10)
+    ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_CAPTURE(PhTree3DSphereITWQ, _100, 100.0)
     ->RangeMultiplier(10)
     ->Ranges({{1000, 1000 * 1000}, {TestGenerator::CUBE, TestGenerator::CLUSTER}})
     ->Unit(benchmark::kMillisecond);

--- a/phtree/common/filter.h
+++ b/phtree/common/filter.h
@@ -364,6 +364,13 @@ class FilterMultiMapSphere {
 
     template <typename T>
     [[nodiscard]] bool IsEntryValid(const KeyInternal& key, const T&) const {
+        //KeyExternal point = converter_.post(key);
+        //return distance_function_(center_external_, point) <= radius_;
+        return true;
+    }
+
+    template <typename ValueT>
+    [[nodiscard]] bool IsBucketEntryValid(const KeyInternal& key, const ValueT&) {
         KeyExternal point = converter_.post(key);
         return distance_function_(center_external_, point) <= radius_;
     }

--- a/phtree/common/filter.h
+++ b/phtree/common/filter.h
@@ -363,7 +363,7 @@ class FilterMultiMapSphere {
     , distance_function_{distance_function} {};
 
     template <typename T>
-    [[nodiscard]] bool IsEntryValid(const KeyInternal& key, const T&) const {
+    [[nodiscard]] bool IsEntryValid(const KeyInternal&, const T&) const {
         //KeyExternal point = converter_.post(key);
         //return distance_function_(center_external_, point) <= radius_;
         return true;

--- a/phtree/phtree_box_d_test.cc
+++ b/phtree/phtree_box_d_test.cc
@@ -172,7 +172,7 @@ void SmokeTestBasicOps(size_t N) {
     PhTreeDebugHelper::CheckConsistency(tree);
 }
 
-TEST(PhTreeDTest, SmokeTestBasicOps) {
+TEST(PhTreeMMDFilterTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<1>(100);
     SmokeTestBasicOps<3>(10000);
     SmokeTestBasicOps<6>(10000);
@@ -181,7 +181,7 @@ TEST(PhTreeDTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<31>(100);
 }
 
-TEST(PhTreeDTest, TestDebug) {
+TEST(PhTreeMMDFilterTest, TestDebug) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;

--- a/phtree/phtree_box_f_test.cc
+++ b/phtree/phtree_box_f_test.cc
@@ -173,7 +173,7 @@ void SmokeTestBasicOps(size_t N) {
     PhTreeDebugHelper::CheckConsistency(tree);
 }
 
-TEST(PhTreeDTest, SmokeTestBasicOps) {
+TEST(PhTreeMMDFilterTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<1>(100);
     SmokeTestBasicOps<3>(10000);
     SmokeTestBasicOps<6>(10000);
@@ -182,7 +182,7 @@ TEST(PhTreeDTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<31>(100);
 }
 
-TEST(PhTreeDTest, TestDebug) {
+TEST(PhTreeMMDFilterTest, TestDebug) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;

--- a/phtree/phtree_d_test.cc
+++ b/phtree/phtree_d_test.cc
@@ -186,7 +186,7 @@ void SmokeTestBasicOps(size_t N) {
     PhTreeDebugHelper::CheckConsistency(tree);
 }
 
-TEST(PhTreeDTest, SmokeTestBasicOps) {
+TEST(PhTreeMMDFilterTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<1>(10000);
     SmokeTestBasicOps<3>(10000);
     SmokeTestBasicOps<6>(10000);
@@ -195,7 +195,7 @@ TEST(PhTreeDTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<63>(100);
 }
 
-TEST(PhTreeDTest, TestDebug) {
+TEST(PhTreeMMDFilterTest, TestDebug) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;
@@ -231,7 +231,7 @@ TEST(PhTreeDTest, TestDebug) {
     Debug::CheckConsistency(tree);
 }
 
-TEST(PhTreeDTest, TestInsert) {
+TEST(PhTreeMMDFilterTest, TestInsert) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;
@@ -270,7 +270,7 @@ TEST(PhTreeDTest, TestInsert) {
     }
 }
 
-TEST(PhTreeDTest, TestEmplace) {
+TEST(PhTreeMMDFilterTest, TestEmplace) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;
@@ -317,7 +317,7 @@ TEST(PhTreeDTest, TestEmplace) {
     }
 }
 
-TEST(PhTreeDTest, TestSquareBrackets) {
+TEST(PhTreeMMDFilterTest, TestSquareBrackets) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;
@@ -380,7 +380,7 @@ void populate(TestTree<DIM, Id>& tree, std::vector<TestPoint<DIM>>& points, size
     ASSERT_EQ(N, tree.size());
 }
 
-TEST(PhTreeDTest, TestClear) {
+TEST(PhTreeMMDFilterTest, TestClear) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 100;
@@ -406,7 +406,7 @@ TEST(PhTreeDTest, TestClear) {
     points.clear();
 }
 
-TEST(PhTreeDTest, TestFind) {
+TEST(PhTreeMMDFilterTest, TestFind) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -433,7 +433,7 @@ TEST(PhTreeDTest, TestFind) {
     ASSERT_NE(tree.end(), iter1);
 }
 
-TEST(PhTreeDTest, TestUpdateWithEmplace) {
+TEST(PhTreeMMDFilterTest, TestUpdateWithEmplace) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -456,7 +456,7 @@ TEST(PhTreeDTest, TestUpdateWithEmplace) {
     tree.clear();
 }
 
-TEST(PhTreeDTest, TestUpdateWithEmplaceHint) {
+TEST(PhTreeMMDFilterTest, TestUpdateWithEmplaceHint) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -485,7 +485,7 @@ TEST(PhTreeDTest, TestUpdateWithEmplaceHint) {
     tree.clear();
 }
 
-TEST(PhTreeDTest, TestEraseByIterator) {
+TEST(PhTreeMMDFilterTest, TestEraseByIterator) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -505,7 +505,7 @@ TEST(PhTreeDTest, TestEraseByIterator) {
     ASSERT_EQ(0, tree.erase(tree.end()));
 }
 
-TEST(PhTreeDTest, TestEraseByIteratorQuery) {
+TEST(PhTreeMMDFilterTest, TestEraseByIteratorQuery) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -522,7 +522,7 @@ TEST(PhTreeDTest, TestEraseByIteratorQuery) {
     ASSERT_EQ(0, tree.erase(tree.end()));
 }
 
-TEST(PhTreeDTest, TestExtent) {
+TEST(PhTreeMMDFilterTest, TestExtent) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -554,7 +554,7 @@ struct FilterEvenId {
     }
 };
 
-TEST(PhTreeDTest, TestExtentFilter) {
+TEST(PhTreeMMDFilterTest, TestExtentFilter) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -572,7 +572,7 @@ TEST(PhTreeDTest, TestExtentFilter) {
     ASSERT_EQ(N, num_e * 2);
 }
 
-TEST(PhTreeDTest, TestRangeBasedForLoop) {
+TEST(PhTreeMMDFilterTest, TestRangeBasedForLoop) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -632,7 +632,7 @@ void testQuery(TestPoint<DIM>& min, TestPoint<DIM>& max, size_t N, int& result) 
     ASSERT_EQ(referenceResult.size(), result);
 }
 
-TEST(PhTreeDTest, TestWindowQuery0) {
+TEST(PhTreeMMDFilterTest, TestWindowQuery0) {
     const dimension_t dim = 3;
     TestPoint<dim> p{-10000, -10000, -10000};
     int n = 0;
@@ -640,7 +640,7 @@ TEST(PhTreeDTest, TestWindowQuery0) {
     ASSERT_EQ(0, n);
 }
 
-TEST(PhTreeDTest, TestWindowQuery1) {
+TEST(PhTreeMMDFilterTest, TestWindowQuery1) {
     size_t N = 1000;
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
@@ -662,7 +662,7 @@ TEST(PhTreeDTest, TestWindowQuery1) {
     ASSERT_EQ(N, n);
 }
 
-TEST(PhTreeDTest, TestWindowQueryMany) {
+TEST(PhTreeMMDFilterTest, TestWindowQueryMany) {
     const dimension_t dim = 3;
     TestPoint<dim> min{-100, -100, -100};
     TestPoint<dim> max{100, 100, 100};
@@ -672,7 +672,7 @@ TEST(PhTreeDTest, TestWindowQueryMany) {
     ASSERT_GE(100, n);
 }
 
-TEST(PhTreeDTest, TestWindowQueryAll) {
+TEST(PhTreeMMDFilterTest, TestWindowQueryAll) {
     const dimension_t dim = 3;
     const size_t N = 10000;
     TestPoint<dim> min{-10000, -10000, -10000};
@@ -682,7 +682,7 @@ TEST(PhTreeDTest, TestWindowQueryAll) {
     ASSERT_EQ(N, n);
 }
 
-TEST(PhTreeDTest, TestWindowQueryManyMoving) {
+TEST(PhTreeMMDFilterTest, TestWindowQueryManyMoving) {
     size_t N = 10000;
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
@@ -716,7 +716,7 @@ TEST(PhTreeDTest, TestWindowQueryManyMoving) {
     ASSERT_GE(5000, nn);
 }
 
-TEST(PhTreeDTest, TestWindowForEachQueryManyMoving) {
+TEST(PhTreeMMDFilterTest, TestWindowForEachQueryManyMoving) {
     size_t N = 10000;
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
@@ -757,7 +757,7 @@ TEST(PhTreeDTest, TestWindowForEachQueryManyMoving) {
     ASSERT_GE(5000, nn);
 }
 
-TEST(PhTreeDTest, TestWindowQueryIterators) {
+TEST(PhTreeMMDFilterTest, TestWindowQueryIterators) {
     size_t N = 1000;
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
@@ -780,7 +780,7 @@ TEST(PhTreeDTest, TestWindowQueryIterators) {
     ASSERT_EQ(N, n);
 }
 
-TEST(PhTreeDTest, TestWindowQueryFilter) {
+TEST(PhTreeMMDFilterTest, TestWindowQueryFilter) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 10000;
@@ -801,7 +801,7 @@ TEST(PhTreeDTest, TestWindowQueryFilter) {
     ASSERT_GE(50, num_e);
 }
 
-TEST(PhTreeDTest, TestKnnQuery) {
+TEST(PhTreeMMDFilterTest, TestKnnQuery) {
     // deliberately allowing outside of main points range
     DoubleRng rng(-1500, 1500);
     const dimension_t dim = 3;
@@ -853,7 +853,7 @@ struct PhDistanceLongL1 {
     };
 };
 
-TEST(PhTreeDTest, TestKnnQueryFilterAndDistanceL1) {
+TEST(PhTreeMMDFilterTest, TestKnnQueryFilterAndDistanceL1) {
     // deliberately allowing outside of main points range
     DoubleRng rng(-1500, 1500);
     const dimension_t dim = 3;
@@ -895,7 +895,7 @@ TEST(PhTreeDTest, TestKnnQueryFilterAndDistanceL1) {
     }
 }
 
-TEST(PhTreeDTest, TestKnnQueryIterator) {
+TEST(PhTreeMMDFilterTest, TestKnnQueryIterator) {
     // deliberately allowing outside of main points range
     DoubleRng rng(-1500, 1500);
     const dimension_t dim = 3;
@@ -922,7 +922,7 @@ TEST(PhTreeDTest, TestKnnQueryIterator) {
     ASSERT_EQ(Nq, n);
 }
 
-TEST(PhTreeDTest, SmokeTestPoint0) {
+TEST(PhTreeMMDFilterTest, SmokeTestPoint0) {
     // Test edge case: empty tree
     TestPoint<3> p{1, 2, 3};
     TestTree<3, Id> tree;
@@ -943,7 +943,7 @@ TEST(PhTreeDTest, SmokeTestPoint0) {
     ASSERT_TRUE(tree.empty());
 }
 
-TEST(PhTreeDTest, SmokeTestPointInfinity) {
+TEST(PhTreeMMDFilterTest, SmokeTestPointInfinity) {
     // Test inifnity.
     double positive_infinity = std::numeric_limits<double>::infinity();
     double negative_infinity = -positive_infinity;
@@ -1002,7 +1002,7 @@ TEST(PhTreeDTest, SmokeTestPointInfinity) {
     ASSERT_TRUE(tree.empty());
 }
 
-TEST(PhTreeDTest, SmokeTestTreeAPI) {
+TEST(PhTreeMMDFilterTest, SmokeTestTreeAPI) {
     std::map<int, Id*> mapPtr;
     PhTreeD<3, Id*> treePtr;
     Id* idPtr = new Id(1);

--- a/phtree/phtree_d_test_filter.cc
+++ b/phtree/phtree_d_test_filter.cc
@@ -455,7 +455,7 @@ void testSphereQuery(TestPoint<DIM>& center, double radius, size_t N, int& resul
     ASSERT_EQ(referenceResult.size(), result);
 }
 
-TEST(PhTreeDTest, TestSphereQuery0) {
+TEST(PhTreeMMDFilterTest, TestSphereQuery0) {
     const dimension_t dim = 3;
     TestPoint<dim> p{-10000, -10000, -10000};
     int n = 0;
@@ -463,7 +463,7 @@ TEST(PhTreeDTest, TestSphereQuery0) {
     ASSERT_EQ(0, n);
 }
 
-TEST(PhTreeDTest, TestSphereQueryMany) {
+TEST(PhTreeMMDFilterTest, TestSphereQueryMany) {
     const dimension_t dim = 3;
     TestPoint<dim> p{0, 0, 0};
     int n = 0;
@@ -472,7 +472,7 @@ TEST(PhTreeDTest, TestSphereQueryMany) {
     ASSERT_LT(n, 800);
 }
 
-TEST(PhTreeDTest, TestSphereQueryAll) {
+TEST(PhTreeMMDFilterTest, TestSphereQueryAll) {
     const dimension_t dim = 3;
     TestPoint<dim> p{0, 0, 0};
     int n = 0;

--- a/phtree/phtree_multimap_box_d_test.cc
+++ b/phtree/phtree_multimap_box_d_test.cc
@@ -583,11 +583,15 @@ TEST(PhTreeMMBoxDTest, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<2 * DIM>&, const T& value) const {
-        return value._i % 2 == 0;
+    template <typename BucketT>
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<2 * DIM>&, const BucketT&) const {
+        return true;
     }
     [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<2 * DIM>&, int) const {
         return true;
+    }
+    [[nodiscard]] constexpr bool IsBucketEntryValid(const PhPoint<2 * DIM>&, const T& value) const {
+        return value._i % 2 == 0;
     }
 };
 

--- a/phtree/phtree_multimap_d_test.cc
+++ b/phtree/phtree_multimap_d_test.cc
@@ -589,11 +589,15 @@ TEST(PhTreeMMDTest, TestExtent) {
 
 template <dimension_t DIM, typename T>
 struct FilterEvenId {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) const {
-        return value._i % 2 == 0;
+    template <typename BucketT>
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const BucketT&) const {
+        return true;
     }
     [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) const {
         return true;
+    }
+    [[nodiscard]] constexpr bool IsBucketEntryValid(const PhPoint<DIM>&, const T& value) const {
+        return value._i % 2 == 0;
     }
 };
 
@@ -1195,7 +1199,7 @@ TEST(PhTreeTest, TestMovableIterators) {
     ASSERT_NE(tree.find(p), tree.end());
 
     TestTree<3, Id>::QueryBox qb{{1, 2, 3}, {4, 5, 6}};
-    FilterAABB filter(p, p, tree.converter());
+    FilterMultiMapAABB filter(p, p, tree.converter());
     ASSERT_TRUE(std::is_move_constructible_v<decltype(tree.begin_query(qb, filter))>);
     // Not movable due to constant fields
     // ASSERT_TRUE(std::is_move_assignable_v<decltype(tree.begin_query(qb, filter))>);

--- a/phtree/phtree_multimap_d_test_filter.cc
+++ b/phtree/phtree_multimap_d_test_filter.cc
@@ -168,10 +168,70 @@ struct FilterCount {
         ++f_destruct_;
     }
 
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) {
-        last_known = const_cast<T&>(value);
+    template <typename BucketT>
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const BucketT& bucket) {
+        assert(!bucket.empty());
         return true;
     }
+
+    template <typename T2>
+    [[nodiscard]] bool IsBucketEntryValid(const PhPoint<DIM>&, const T2& value) {
+        last_known = value;
+        return true;
+    }
+
+    [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) {
+        return true;
+    }
+
+    T last_known;
+};
+
+/*
+ * Legacy filter: The pre 1.1 release allowed using normal filters to be used.
+ * While this is highly inefficient, it should still continue to work.
+ */
+template <dimension_t DIM, typename T>
+struct FilterCountLegacy {
+    FilterCountLegacy() : last_known{} {
+        ++f_default_construct_;
+    }
+
+    explicit FilterCountLegacy(const T i) : last_known{i} {
+        ++f_construct_;
+    }
+
+    FilterCountLegacy(const FilterCountLegacy& other) {
+        ++f_copy_construct_;
+        last_known = other.last_known;
+    }
+
+    FilterCountLegacy(FilterCountLegacy&& other) noexcept {
+        ++f_move_construct_;
+        last_known = other.last_known;
+    }
+
+    FilterCountLegacy& operator=(const FilterCountLegacy& other) noexcept {
+        ++f_copy_assign_;
+        last_known = other.last_known;
+        return *this;
+    }
+
+    FilterCountLegacy& operator=(FilterCountLegacy&& other) noexcept {
+        ++f_move_assign_;
+        last_known = other.last_known;
+        return *this;
+    }
+
+    ~FilterCountLegacy() {
+        ++f_destruct_;
+    }
+
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) {
+        last_known = value;
+        return true;
+    }
+
     [[nodiscard]] constexpr bool IsNodeValid(const PhPoint<DIM>&, int) {
         return true;
     }
@@ -253,7 +313,11 @@ struct CallbackCount {
 
 template <dimension_t DIM, typename T>
 struct FilterConst {
-    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const T& value) const {
+    template <typename BucketT>
+    [[nodiscard]] constexpr bool IsEntryValid(const PhPoint<DIM>&, const BucketT&) const {
+        return true;
+    }
+    [[nodiscard]] constexpr bool IsBucketEntryValid(const PhPoint<DIM>&, const T& value) {
         assert(value._i == 1);
         return true;
     }
@@ -276,6 +340,18 @@ struct CallbackConst {
               << std::endl;
 }
 
+/*
+ * General comment: We are testing several thing here.
+ * - If we pass lvalue filters/callbacks/... we want to ensure that they do not get copied or
+ *   moved at all. We need to ensure that the lvalue argument is the same instance that is
+ *   used internally by the iterator.
+ * - If we pass a rvalue filters/callbacks/..., preventing copies/moves is harder. We are testing
+ *   somewhat arbitrarily for a limit of 3 moves/copies per argument.
+ * - We want to ensure that both rvalue/lvalue arguments work.
+ * - We also do some limited testing that it works with 'const' trees.
+ * - Finally, we test separately that the old legacy filters still work
+ */
+
 TEST(PhTreeTest, TestFilterAPI_FOR_EACH) {
     // Test edge case: only one entry in tree
     PhPointD<3> p{1, 2, 3};
@@ -287,6 +363,7 @@ TEST(PhTreeTest, TestFilterAPI_FOR_EACH) {
     // rvalue
     tree.for_each(callback, filter);
     ASSERT_EQ(static_id, 1);
+    ASSERT_EQ(filter.last_known._i, 1);
     ASSERT_EQ(2, f_construct_ + f_default_construct_);
     ASSERT_EQ(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
@@ -295,7 +372,7 @@ TEST(PhTreeTest, TestFilterAPI_FOR_EACH) {
     tree.for_each(CallbackCount<3>(), FilterCount<3, Id>());
     ASSERT_EQ(static_id, 1);
     ASSERT_EQ(2, f_construct_ + f_default_construct_);
-    ASSERT_LE(1, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+    ASSERT_GE(4, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
 
     // const Tree: just test that it compiles
@@ -321,6 +398,7 @@ TEST(PhTreeTest, TestFilterAPI_FOR_EACH_WQ) {
     // lvalue
     tree.for_each(qb, callback, filter);
     ASSERT_EQ(static_id, 1);
+    ASSERT_EQ(filter.last_known._i, 1);
     ASSERT_EQ(2, f_construct_ + f_default_construct_);
     ASSERT_EQ(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
@@ -329,7 +407,7 @@ TEST(PhTreeTest, TestFilterAPI_FOR_EACH_WQ) {
     tree.for_each({{1, 2, 3}, {4, 5, 6}}, CallbackCount<3>{}, FilterCount<3, Id>());
     ASSERT_EQ(static_id, 1);
     ASSERT_EQ(2, f_construct_ + f_default_construct_);
-    ASSERT_LE(1, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+    ASSERT_GE(4, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
 
     // const Tree: just test that it compiles
@@ -351,14 +429,15 @@ TEST(PhTreeTest, TestFilterAPI_BEGIN) {
     FilterCount<3, Id> filter{};
     // lvalue
     ASSERT_EQ(tree.begin(filter)->_i, 1);
+    ASSERT_EQ(filter.last_known._i, 1);
     ASSERT_EQ(1, f_construct_ + f_default_construct_);
-    ASSERT_EQ(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+    ASSERT_GE(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
 
     // rvalue
     ASSERT_EQ(tree.begin(FilterCount<3, Id>())->_i, 1);
     ASSERT_EQ(1, f_construct_ + f_default_construct_);
-    ASSERT_LE(1, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+    ASSERT_GE(2, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
 
     // const Tree: just test that it compiles
@@ -381,6 +460,7 @@ TEST(PhTreeTest, TestFilterAPI_WQ) {
     FilterCount<3, Id> filter{};
     // lvalue
     ASSERT_EQ(tree.begin_query(qb, filter)->_i, 1);
+    ASSERT_EQ(filter.last_known._i, 1);
     ASSERT_EQ(1, f_construct_ + f_default_construct_);
     ASSERT_EQ(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
@@ -388,7 +468,7 @@ TEST(PhTreeTest, TestFilterAPI_WQ) {
     // rvalue
     ASSERT_EQ(tree.begin_query({{1, 2, 3}, {4, 5, 6}}, FilterCount<3, Id>())->_i, 1);
     ASSERT_EQ(1, f_construct_ + f_default_construct_);
-    ASSERT_LE(1, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+    ASSERT_GE(2, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
 
     // const Tree: just test that it compiles
@@ -411,6 +491,7 @@ TEST(PhTreeTest, TestFilterAPI_KNN) {
     DistanceCount<3> dist_fn{};
     // lvalue
     ASSERT_EQ(tree.begin_knn_query(3, {2, 3, 4}, dist_fn, filter)->_i, 1);
+    ASSERT_EQ(filter.last_known._i, 1);
     ASSERT_EQ(2, f_construct_ + f_default_construct_);
     ASSERT_EQ(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
@@ -418,14 +499,14 @@ TEST(PhTreeTest, TestFilterAPI_KNN) {
     // rvalue
     ASSERT_EQ(tree.begin_knn_query(3, {2, 3, 4}, DistanceCount<3>{}, FilterCount<3, Id>())->_i, 1);
     ASSERT_EQ(2, f_construct_ + f_default_construct_);
-    ASSERT_LE(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+    ASSERT_GE(2 * 3, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
 
     // rvalue #2
     auto a = tree.begin_knn_query<DistanceCount<3>, FilterCount<3, Id>>(3, {2, 3, 4})->_i;
     ASSERT_EQ(a, 1);
     ASSERT_EQ(2, f_construct_ + f_default_construct_);
-    ASSERT_LE(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+    ASSERT_GE(2 * 3, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
     f_reset_id_counters();
 
     // const Tree: just test that it compiles
@@ -436,4 +517,127 @@ TEST(PhTreeTest, TestFilterAPI_KNN) {
     // rvalue
     ASSERT_EQ(treeC.begin_knn_query(3, {2, 3, 4}, DistanceCount<3>{}, FilterConst<3, Id>())->_i, 1);
     f_reset_id_counters();
+}
+
+// TODO !!!!
+// TEST(PhTreeTest, TestLegacyFilter) {
+//    // Test edge case: only one entry in tree
+//    PhPointD<3> p{1, 2, 3};
+//    auto tree = TestTree<3, Id>();
+//    tree.emplace(p, Id{1});
+//    f_reset_id_counters();
+//
+//    // lvalue
+//    auto filter1 = FilterCountLegacy<3, Id>();
+//    ASSERT_EQ(tree.begin(filter1)->_i, 1);
+//    ASSERT_EQ(filter1.last_known._i, 1);
+//    ASSERT_EQ(1, f_construct_ + f_default_construct_);
+//    ASSERT_GE(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+//    f_reset_id_counters();
+//
+//    TestTree<3, Id>::QueryBox qb{{1, 2, 3}, {4, 5, 6}};
+//    auto filter2 = FilterCountLegacy<3, Id>();
+//    ASSERT_EQ(tree.begin_query(qb, filter2)->_i, 1);
+//    ASSERT_EQ(filter2.last_known._i, 1);
+//    ASSERT_EQ(1, f_construct_ + f_default_construct_);
+//    ASSERT_EQ(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+//    f_reset_id_counters();
+//
+//    FilterCount<3, Id> filter3{};
+//    DistanceCount<3> dist_fn{};
+//    ASSERT_EQ(tree.begin_knn_query(3, {2, 3, 4}, dist_fn, filter3)->_i, 1);
+//    ASSERT_EQ(filter3.last_known._i, 1);
+//    ASSERT_EQ(2, f_construct_ + f_default_construct_);
+//    ASSERT_EQ(0, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+//    f_reset_id_counters();
+//
+//    // rvalue
+//    ASSERT_EQ(tree.begin(FilterCountLegacy<3, Id>())->_i, 1);
+//    ASSERT_EQ(1, f_construct_ + f_default_construct_);
+//    ASSERT_GE(3, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+//    f_reset_id_counters();
+//
+//    auto it = tree.begin_query<FilterCountLegacy<3, Id>>({{1, 2, 3}, {2, 3, 4}});
+//    ASSERT_EQ(it->_i, 1);
+//    ASSERT_EQ(1, f_construct_ + f_default_construct_);
+//    ASSERT_GE(3, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+//    f_reset_id_counters();
+//
+//    ASSERT_EQ(
+//        tree.begin_knn_query(3, {2, 3, 4}, DistanceCount<3>{}, FilterCountLegacy<3, Id>())->_i,
+//        1);
+//    ASSERT_EQ(2, f_construct_ + f_default_construct_);
+//    ASSERT_GE(3 * 2, f_copy_construct_ + f_move_construct_ + f_copy_assign_ + f_move_assign_);
+//    f_reset_id_counters();
+//}
+
+template <dimension_t DIM>
+double distance(const TestPoint<DIM>& p1, const TestPoint<DIM>& p2) {
+    double sum2 = 0;
+    for (dimension_t i = 0; i < DIM; ++i) {
+        double d2 = p1[i] - p2[i];
+        sum2 += d2 * d2;
+    }
+    return sqrt(sum2);
+};
+
+template <dimension_t DIM>
+void referenceSphereQuery(
+    std::vector<TestPoint<DIM>>& points,
+    TestPoint<DIM>& center,
+    double radius,
+    std::set<size_t>& result) {
+    for (size_t i = 0; i < points.size(); i++) {
+        auto& p = points[i];
+        if (distance(center, p) <= radius) {
+            result.insert(i);
+        }
+    }
+}
+
+// We use 'int&' because gtest does not compile with assertions in non-void functions.
+template <dimension_t DIM>
+void testSphereQuery(TestPoint<DIM>& center, double radius, size_t N, int& result) {
+    TestTree<DIM, size_t> tree;
+    std::vector<TestPoint<DIM>> points;
+    populate(tree, points, N);
+
+    std::set<size_t> referenceResult;
+    referenceSphereQuery(points, center, radius, referenceResult);
+
+    result = 0;
+    // TODO
+    auto filter = FilterMultiMapSphere(center, radius, tree.converter());
+    for (auto it = tree.begin(filter); it != tree.end(); it++) {
+        auto& x = *it;
+        ASSERT_GE(x, 0);
+        ASSERT_EQ(referenceResult.count(x), 1);
+        result++;
+    }
+    ASSERT_EQ(referenceResult.size(), result);
+}
+
+TEST(PhTreeDTest, TestSphereQuery0) {
+    const dimension_t dim = 3;
+    TestPoint<dim> p{-10000, -10000, -10000};
+    int n = 0;
+    testSphereQuery<dim>(p, 0.1, 100, n);
+    ASSERT_EQ(0, n);
+}
+
+TEST(PhTreeDTest, TestSphereQueryMany) {
+    const dimension_t dim = 3;
+    TestPoint<dim> p{0, 0, 0};
+    int n = 0;
+    testSphereQuery<dim>(p, 1000, 1000, n);
+    ASSERT_GT(n, 400);
+    ASSERT_LT(n, 800);
+}
+
+TEST(PhTreeDTest, TestSphereQueryAll) {
+    const dimension_t dim = 3;
+    TestPoint<dim> p{0, 0, 0};
+    int n = 0;
+    testSphereQuery<dim>(p, 10000, 1000, n);
+    ASSERT_EQ(1000, n);
 }

--- a/phtree/v16/iterator_base.h
+++ b/phtree/v16/iterator_base.h
@@ -94,7 +94,7 @@ class IteratorWithFilter
   public:
     template <typename F>
     explicit IteratorWithFilter(const CONVERT* converter, F&& filter) noexcept
-    : IteratorBase<EntryT>(nullptr), converter_{converter}, filter_(std::forward<F>(filter)) {}
+    : IteratorBase<EntryT>(nullptr), converter_{converter}, filter_{std::forward<F>(filter)} {}
 
     explicit IteratorWithFilter(const EntryT* current_result, const CONVERT* converter) noexcept
     : IteratorBase<EntryT>(current_result), converter_{converter}, filter_{FILTER()} {}


### PR DESCRIPTION
See issue #26.
Improve the API for `PhTreeMultiMap`. The current API expects filters that can filter nodes or entries.
The multimap uses collections ("buckets") at each coordinate to store multiple values.
As a result, the current implementation calls the filter once for every entry in every candidate bucket.
This is correct but inefficient.

Many filters will constrain on the coordinate (e.g. `FilterSphere`). It would be efficient if such a filter would be called only once per bucket, not once per entry in the bucket.

The new API enforces filters with three filter methods:
- `IsNodeValid(...)` filters nodes.
- `IsEntryValid(...)` filters buckets. It is called `...Entry...` because each bucket is an entry in the internal `PhTree`.
- `IsBucketEntryValid(...)` filters entries in buckets.

This change breaks the API.