### PR TITLE
Cleanup unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added FilterBoxAABB and FilterSphereAABB as examples for filtering a PH-Tree with box keys
   [#33](https://github.com/tzaeschke/phtree-cpp/issues/33)
 ### Changed
-- Simplified internals of erase(). [#47](https://github.com/tzaeschke/phtree-cpp/pull/47)
+- Cleaned up unit tests. [#54](https://github.com/tzaeschke/phtree-cpp/pull/54)
+- Simplified internals of `erase()`. [#47](https://github.com/tzaeschke/phtree-cpp/pull/47)
 - Removed internal use of `std::optional()` to slightly reduce memory overhead
   [#38](https://github.com/tzaeschke/phtree-cpp/issues/38)
 - Removed restrictions on bazel version [#35](https://github.com/tzaeschke/phtree-cpp/issues/35)

--- a/phtree/phtree_box_d_test.cc
+++ b/phtree/phtree_box_d_test.cc
@@ -39,11 +39,9 @@ struct Id {
 
     explicit Id(const size_t i) : _i(i){};
 
-    bool operator==(Id& rhs) {
+    bool operator==(const Id& rhs) const {
         return _i == rhs._i;
     }
-
-    Id& operator=(Id const& rhs) = default;
 
     size_t _i;
 };
@@ -172,7 +170,7 @@ void SmokeTestBasicOps(size_t N) {
     PhTreeDebugHelper::CheckConsistency(tree);
 }
 
-TEST(PhTreeMMDFilterTest, SmokeTestBasicOps) {
+TEST(PhTreeBoxDTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<1>(100);
     SmokeTestBasicOps<3>(10000);
     SmokeTestBasicOps<6>(10000);
@@ -181,7 +179,7 @@ TEST(PhTreeMMDFilterTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<31>(100);
 }
 
-TEST(PhTreeMMDFilterTest, TestDebug) {
+TEST(PhTreeBoxDTest, TestDebug) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;

--- a/phtree/phtree_box_d_test_filter.cc
+++ b/phtree/phtree_box_d_test_filter.cc
@@ -601,31 +601,31 @@ void QueryAll(QUERY query) {
     ASSERT_EQ(1000, n);
 }
 
-TEST(PhTreeMMDFilterTest, TestSphereQuery) {
+TEST(PhTreeBoxDFilterTest, TestSphereQuery) {
     Query0<3>(&testSphereQuery<3>);
     QueryMany<3>(&testSphereQuery<3>);
     QueryAll<3>(&testSphereQuery<3>);
 }
 
-TEST(PhTreeMMDFilterTest, TestSphereQueryWithQueryBox) {
+TEST(PhTreeBoxDFilterTest, TestSphereQueryWithQueryBox) {
     Query0<3>(&testSphereQueryWithBox<3>);
     QueryMany<3>(&testSphereQueryWithBox<3>);
     QueryAll<3>(&testSphereQueryWithBox<3>);
 }
 
-TEST(PhTreeMMDFilterTest, TestSphereQueryForEach) {
+TEST(PhTreeBoxDFilterTest, TestSphereQueryForEach) {
     Query0<3>(&testSphereQueryForEach<3>);
     QueryMany<3>(&testSphereQueryForEach<3>);
     QueryAll<3>(&testSphereQueryForEach<3>);
 }
 
-TEST(PhTreeMMDFilterTest, TestSphereQueryForEachWithQueryBox) {
+TEST(PhTreeBoxDFilterTest, TestSphereQueryForEachWithQueryBox) {
     Query0<3>(&testSphereQueryForEachQueryBox<3>);
     QueryMany<3>(&testSphereQueryForEachQueryBox<3>);
     QueryAll<3>(&testSphereQueryForEachQueryBox<3>);
 }
 
-TEST(PhTreeMMDFilterTest, TestAABBQuery) {
+TEST(PhTreeBoxDFilterTest, TestAABBQuery) {
     Query0<3>(&testAABBQuery<3>);
     QueryManyAABB<3>(&testAABBQuery<3>);
     QueryAll<3>(&testAABBQuery<3>);

--- a/phtree/phtree_box_f_test.cc
+++ b/phtree/phtree_box_f_test.cc
@@ -46,11 +46,9 @@ struct Id {
 
     explicit Id(const size_t i) : _i(i){};
 
-    bool operator==(Id& rhs) {
+    bool operator==(const Id& rhs) const {
         return _i == rhs._i;
     }
-
-    Id& operator=(Id const& rhs) = default;
 
     size_t _i;
 };
@@ -173,7 +171,7 @@ void SmokeTestBasicOps(size_t N) {
     PhTreeDebugHelper::CheckConsistency(tree);
 }
 
-TEST(PhTreeMMDFilterTest, SmokeTestBasicOps) {
+TEST(PhTreeBoxFTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<1>(100);
     SmokeTestBasicOps<3>(10000);
     SmokeTestBasicOps<6>(10000);
@@ -182,7 +180,7 @@ TEST(PhTreeMMDFilterTest, SmokeTestBasicOps) {
     SmokeTestBasicOps<31>(100);
 }
 
-TEST(PhTreeMMDFilterTest, TestDebug) {
+TEST(PhTreeBoxFTest, TestDebug) {
     const dimension_t dim = 3;
     TestTree<dim, Id> tree;
     size_t N = 1000;

--- a/phtree/phtree_d_test_filter.cc
+++ b/phtree/phtree_d_test_filter.cc
@@ -455,7 +455,7 @@ void testSphereQuery(TestPoint<DIM>& center, double radius, size_t N, int& resul
     ASSERT_EQ(referenceResult.size(), result);
 }
 
-TEST(PhTreeMMDFilterTest, TestSphereQuery0) {
+TEST(PhTreeDFilterTest, TestSphereQuery0) {
     const dimension_t dim = 3;
     TestPoint<dim> p{-10000, -10000, -10000};
     int n = 0;
@@ -463,7 +463,7 @@ TEST(PhTreeMMDFilterTest, TestSphereQuery0) {
     ASSERT_EQ(0, n);
 }
 
-TEST(PhTreeMMDFilterTest, TestSphereQueryMany) {
+TEST(PhTreeDFilterTest, TestSphereQueryMany) {
     const dimension_t dim = 3;
     TestPoint<dim> p{0, 0, 0};
     int n = 0;
@@ -472,7 +472,7 @@ TEST(PhTreeMMDFilterTest, TestSphereQueryMany) {
     ASSERT_LT(n, 800);
 }
 
-TEST(PhTreeMMDFilterTest, TestSphereQueryAll) {
+TEST(PhTreeDFilterTest, TestSphereQueryAll) {
     const dimension_t dim = 3;
     TestPoint<dim> p{0, 0, 0};
     int n = 0;

--- a/phtree/phtree_d_test_preprocessor.cc
+++ b/phtree/phtree_d_test_preprocessor.cc
@@ -44,11 +44,9 @@ struct Id {
 
     explicit Id(const int i) : _i(i){};
 
-    bool operator==(Id& rhs) {
+    bool operator==(const Id& rhs) const {
         return _i == rhs._i;
     }
-
-    Id& operator=(Id const& rhs) = default;
 
     int _i;
 };

--- a/phtree/phtree_f_test.cc
+++ b/phtree/phtree_f_test.cc
@@ -45,11 +45,9 @@ struct Id {
 
     explicit Id(const int i) : _i(i){};
 
-    bool operator==(Id& rhs) {
+    bool operator==(const Id& rhs) const {
         return _i == rhs._i;
     }
-
-    Id& operator=(Id const& rhs) = default;
 
     int _i;
 };

--- a/phtree/phtree_test_const_values.cc
+++ b/phtree/phtree_test_const_values.cc
@@ -44,11 +44,9 @@ struct Id {
 
     explicit Id(const int i) : _i(i){};
 
-    bool operator==(Id& rhs) {
+    bool operator==(const Id& rhs) const {
         return _i == rhs._i;
     }
-
-    Id& operator=(Id const& rhs) = default;
 
     int _i;
 };

--- a/phtree/phtree_test_ptr_values.cc
+++ b/phtree/phtree_test_ptr_values.cc
@@ -44,11 +44,9 @@ struct Id {
 
     explicit Id(const size_t i) : _i((int)i){};
 
-    bool operator==(Id& rhs) const {
+    bool operator==(const Id& rhs) const {
         return _i == rhs._i;
     }
-
-    Id& operator=(Id const& rhs) = default;
 
     int _i;
 };


### PR DESCRIPTION
- Fixed some unit test names
- Fixed `==` operators of some `Id` classes
- Removed bad `=` copy assignment operators from some `Id` classes