### PR TITLE
Result: this does not work. Technical problem: We want to _avoid_ upd…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Added flag to relocate() allow short cutting in case of identical keys.
+  [#68](https://github.com/tzaeschke/phtree-cpp/issues/68)
 - Added tested support for move-only and copy-only value objects.
   [#56](https://github.com/tzaeschke/phtree-cpp/issues/56)
 - Added custom bucket implementation (similar to std::unordered_set). This improves update performance by 5%-20%.

--- a/phtree/phtree_multimap.h
+++ b/phtree/phtree_multimap.h
@@ -413,11 +413,19 @@ class PhTreeMultiMap {
      * @param new_key The new position
      * @param value The value that needs to be relocated. The relocate() method used the value's
      *              '==' operator to identify the entry that should be moved.
+     * @param count_equals This setting toggles whether a relocate() between two identical keys
+     *              should be counted as 'success' and return '1'. The function may still return '0'
+     *              in case the keys are not in the index.
+     *              Background: the intuitively correct behavior is to return '1' for identical
+     *              (exising) keys. However, avoiding this check can considerably speed up
+     *              relocate() calls, especially when using a ConverterMultiply.
+     *
      * @return '1' if a value was found and reinserted, otherwise '0'.
      */
     template <typename T2>
-    size_t relocate(const Key& old_key, const Key& new_key, T2&& value) {
-        auto pair = tree_._find_or_create_two_mm(converter_.pre(old_key), converter_.pre(new_key));
+    size_t relocate(const Key& old_key, const Key& new_key, T2&& value, bool count_equals = true) {
+        auto pair = tree_._find_or_create_two_mm(
+            converter_.pre(old_key), converter_.pre(new_key), count_equals);
         auto& iter_old = pair.first;
         auto& iter_new = pair.second;
 
@@ -469,11 +477,20 @@ class PhTreeMultiMap {
      * @param new_key The new position
      * @param predicate The predicate that is used for every value at position old_key to evaluate
      *             whether it should be relocated to new_key.
+     * @param count_equals This setting toggles whether a relocate() between two identical keys
+     *              should be counted as 'success' and return '1'. The function may still return '0'
+     *              in case the keys are not in the index.
+     *              Background: the intuitively correct behavior is to return '1' for identical
+     *              (exising) keys. However, avoiding this check can considerably speed up
+     *              relocate() calls, especially when using a ConverterMultiply.
+     *
      * @return the number of values that were relocated.
      */
     template <typename PREDICATE>
-    size_t relocate_if(const Key& old_key, const Key& new_key, PREDICATE&& predicate) {
-        auto pair = tree_._find_or_create_two_mm(converter_.pre(old_key), converter_.pre(new_key));
+    size_t relocate_if(
+        const Key& old_key, const Key& new_key, PREDICATE&& predicate, bool count_equals = true) {
+        auto pair = tree_._find_or_create_two_mm(
+            converter_.pre(old_key), converter_.pre(new_key), count_equals);
         auto& iter_old = pair.first;
         auto& iter_new = pair.second;
 

--- a/phtree/v16/phtree_v16.h
+++ b/phtree/v16/phtree_v16.h
@@ -371,9 +371,14 @@ class PhTreeV16 {
      * - returns end() if old_key does not exist;
      * - CREATES the destination entry if it does not exist!
      */
-    auto _find_or_create_two_mm(const KeyT& old_key, const KeyT& new_key) {
+    auto _find_or_create_two_mm(const KeyT& old_key, const KeyT& new_key, bool count_equals) {
         using Iter = IteratorWithParent<T, CONVERT>;
         bit_width_t n_diverging_bits = NumberOfDivergingBits(old_key, new_key);
+
+        if (!count_equals && n_diverging_bits == 0) {
+            auto iter = Iter(nullptr, nullptr, nullptr, converter_);
+            return std::make_pair(iter, iter);
+        }
 
         const EntryT* new_entry = &root_;        // An entry.
         const EntryT* old_node_entry = nullptr;  // Node that contains entry to be removed


### PR DESCRIPTION
See #68. Added flag to `relocate()` and `relocate_if()` for short cutting checks in case of identical keys.
This can bring immense performance improvements when used with a ConverterMultiply that rounds coordinates, e.g. `ConverterMtultiply<2, 1, 100>`.