### PR TITLE
Predefined maps for 32bit floating points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added B+tree multimap for internal (future) use. [#93](https://github.com/tzaeschke/phtree-cpp/issues/93)
 - Added some fuzz tests. Not that these require manual compilation, see [fuzzer/README.md](fuzzer/README.md).
   [#114](https://github.com/tzaeschke/phtree-cpp/pull/114)
+- Added float-32 variants to multimap: PhTreeMultiMapF, PhTreeMultiMapBoxF. 
+  [#117](https://github.com/tzaeschke/phtree-cpp/pull/117)
 
 ### Changed
 - Clean up array_map. [#107](https://github.com/tzaeschke/phtree-cpp/issues/107),

--- a/include/phtree/phtree.h
+++ b/include/phtree/phtree.h
@@ -368,7 +368,7 @@ class PhTree {
     CONVERTER converter_;
 };
 
-/*
+/**
  * Floating-point `double` version of the PH-Tree.
  * This version of the tree accepts multi-dimensional keys with floating point (`double`)
  * coordinates.
@@ -383,23 +383,25 @@ class PhTree {
 template <dimension_t DIM, typename T, typename CONVERTER = ConverterIEEE<DIM>>
 using PhTreeD = PhTree<DIM, T, CONVERTER>;
 
-/*
+/**
  * Floating-point `float` version of the PH-Tree.
  * This version of the tree accepts multi-dimensional keys with floating point (`float`)
  * coordinates.
- *
  * See 'PhTreeD' for details.
  */
 template <dimension_t DIM, typename T, typename CONVERTER = ConverterFloatIEEE<DIM>>
 using PhTreeF = PhTree<DIM, T, CONVERTER>;
 
+/**
+ * A PH-Tree that uses (axis aligned) boxes as keys.
+ * See 'PhTreeD' for details.
+ */
 template <dimension_t DIM, typename T, typename CONVERTER_BOX>
 using PhTreeBox = PhTree<DIM, T, CONVERTER_BOX>;
 
 /**
  * A PH-Tree that uses (axis aligned) boxes as keys.
  * The boxes are defined with 64bit 'double' floating point coordinates.
- *
  * See 'PhTreeD' for details.
  */
 template <dimension_t DIM, typename T, typename CONVERTER_BOX = ConverterBoxIEEE<DIM>>
@@ -408,7 +410,6 @@ using PhTreeBoxD = PhTreeBox<DIM, T, CONVERTER_BOX>;
 /**
  * A PH-Tree that uses (axis aligned) boxes as keys.
  * The boxes are defined with 32bit 'float' coordinates.
- *
  * See 'PhTreeD' for details.
  */
 template <dimension_t DIM, typename T, typename CONVERTER_BOX = ConverterBoxFloatIEEE<DIM>>

--- a/include/phtree/phtree_multimap.h
+++ b/include/phtree/phtree_multimap.h
@@ -823,7 +823,6 @@ class PhTreeMultiMap {
 /**
  * A PH-Tree multi-map that uses (axis aligned) points as keys.
  * The points are defined with 64bit 'double' floating point coordinates.
- *
  * See 'PhTreeD' for details.
  */
 template <
@@ -833,6 +832,22 @@ template <
     typename BUCKET = b_plus_tree_hash_set<T>>
 using PhTreeMultiMapD = PhTreeMultiMap<DIM, T, CONVERTER, BUCKET>;
 
+/**
+ * A PH-Tree multi-map that uses (axis aligned) points as keys.
+ * The points are defined with 32bit 'float' floating point coordinates.
+ * See 'PhTreeD' for details.
+ */
+template <
+    dimension_t DIM,
+    typename T,
+    typename CONVERTER = ConverterFloatIEEE<DIM>,
+    typename BUCKET = b_plus_tree_hash_set<T>>
+using PhTreeMultiMapF = PhTreeMultiMap<DIM, T, CONVERTER, BUCKET>;
+
+/**
+ * A PH-Tree that uses (axis aligned) boxes as keys.
+ * See 'PhTreeD' for details.
+ */
 template <
     dimension_t DIM,
     typename T,
@@ -843,7 +858,6 @@ using PhTreeMultiMapBox = PhTreeMultiMap<DIM, T, CONVERTER_BOX, BUCKET, false, Q
 /**
  * A PH-Tree multi-map that uses (axis aligned) boxes as keys.
  * The boxes are defined with 64bit 'double' floating point coordinates.
- *
  * See 'PhTreeD' for details.
  */
 template <
@@ -852,6 +866,18 @@ template <
     typename CONVERTER_BOX = ConverterBoxIEEE<DIM>,
     typename BUCKET = b_plus_tree_hash_set<T>>
 using PhTreeMultiMapBoxD = PhTreeMultiMapBox<DIM, T, CONVERTER_BOX, BUCKET>;
+
+/**
+ * A PH-Tree multi-map that uses (axis aligned) boxes as keys.
+ * The boxes are defined with 32bit 'float' floating point coordinates.
+ * See 'PhTreeD' for details.
+ */
+template <
+    dimension_t DIM,
+    typename T,
+    typename CONVERTER_BOX = ConverterBoxFloatIEEE<DIM>,
+    typename BUCKET = b_plus_tree_hash_set<T>>
+using PhTreeMultiMapBoxF = PhTreeMultiMapBox<DIM, T, CONVERTER_BOX, BUCKET>;
 
 }  // namespace improbable::phtree
 


### PR DESCRIPTION
Add predefined types for 32bit floating point multimaps: `PhTreeMultiMapF` and `PhTreeMultiMapBoxF`. 