### PR TITLE
Move stuff in common into detail namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added benchmark for bit operations in `common`.  [#128](https://github.com/tzaeschke/phtree-cpp/pull/128)
+- Added benchmark for bit operations in `common`. [#128](https://github.com/tzaeschke/phtree-cpp/pull/128)
 - Added `lower_bounds(key)` to API. [#126](https://github.com/tzaeschke/phtree-cpp/issues/126)
 - Added `bpt_fixed_vector`, a fixed size flat vector for future use. It can be dropped in for an std::vector.
   [#124](https://github.com/tzaeschke/phtree-cpp/pull/124)
+
+### Changed
+- Moved some stuff in `common` into `nemaspace detail`. [#129](https://github.com/tzaeschke/phtree-cpp/issues/129)
 
 ## [1.5.0] - 2023-02-09
 ### Added

--- a/include/phtree/common/base_types.h
+++ b/include/phtree/common/base_types.h
@@ -39,7 +39,9 @@ namespace improbable::phtree {
 using scalar_64_t = int64_t;
 using scalar_32_t = int32_t;
 using scalar_16_t = int16_t;
+using dimension_t = size_t;  // Number of dimensions
 
+namespace detail {
 // Bits in a coordinate (usually a double or long has 64 bits, so uint_8 suffices).
 // However, uint32_t turned out to be faster, probably due to fewer cycles required for 32bit
 // instructions (8bit/16bit tend to require more cycles, see CPU tables available on the web).
@@ -54,16 +56,16 @@ template <typename SCALAR>
 using bit_mask_t = typename std::make_unsigned<SCALAR>::type;
 template <typename SCALAR>
 static constexpr bit_mask_t<SCALAR> MAX_MASK = std::numeric_limits<bit_mask_t<SCALAR>>::max();
-using dimension_t = size_t;  // Number of dimensions
 // We have two types that represent hypercube addresses (HC position).
 // The hc_pos_dim_t uses a template parameter to determine how many bits are needed, this is either
 // 32bit or 64bit. This parameter is used where HC positions are stored because benchmarks show a
 // difference in performance when this is used.
 // The hc_pos_64_t type is always set to 64. It is used where computations play a role that appear
 // to prefer being in always 64bit, mainly in CalcPosInArray() and in Node.
-template<dimension_t DIM>
+template <dimension_t DIM>
 using hc_pos_dim_t = std::conditional_t<(DIM < 32), uint32_t, uint64_t>;
 using hc_pos_64_t = uint64_t;
+}  // namespace detail
 
 // ************************************************************************
 // Basic structs and classes
@@ -120,7 +122,7 @@ class PhBox {
     }
 
     auto operator!=(const PhBox<DIM, SCALAR>& other) const -> bool {
-        return !(*this == other);
+        return min_ != other.min_ || max_ != other.max_;
     }
 
   private:

--- a/include/phtree/common/bits.h
+++ b/include/phtree/common/bits.h
@@ -32,7 +32,7 @@
  * - count leading zeroes
  * - count trailing zeros
  */
-namespace improbable::phtree {
+namespace improbable::phtree::detail {
 
 namespace {
 inline bit_width_t NumberOfLeadingZeros(std::uint64_t bit_string) {
@@ -180,6 +180,6 @@ inline bit_width_t NumberOfTrailingZeros_MSVC_BUILTIN(std::uint32_t bit_string) 
 #define CountTrailingZeros(bits) NumberOfTrailingZeros(bits)
 #endif
 
-}  // namespace improbable::phtree
+}  // namespace improbable::phtree::detail
 
 #endif  // PHTREE_COMMON_BITS_H

--- a/include/phtree/common/common.h
+++ b/include/phtree/common/common.h
@@ -29,7 +29,7 @@
 #include <limits>
 #include <sstream>
 
-namespace improbable::phtree {
+namespace improbable::phtree::detail {
 
 // This is the single-point inclusion file for common types/function/... for the PH-Tree.
 // 'single-point inclusion' meaning that including it provides all relevant types/functions/... .
@@ -103,7 +103,6 @@ static bit_width_t NumberOfDivergingBits(
     return MAX_BIT_WIDTH<SCALAR> - CountLeadingZeros(diff2);
 }
 
-namespace detail {
 template <dimension_t DIM, typename SCALAR, typename MASK>
 void CalcLimits(
     bit_width_t postfix_len,
@@ -162,7 +161,6 @@ void CalcLimits(
         }
     }
 }
-}  // namespace detail
 
 template <dimension_t DIM, typename SCALAR>
 static bool KeyEquals(
@@ -213,6 +211,6 @@ static inline std::string ToBinary(
     return sb.str();
 }
 
-}  // namespace improbable::phtree
+}  // namespace improbable::phtree::detail
 
 #endif  // PHTREE_COMMON_COMMON_H

--- a/include/phtree/common/flat_array_map.h
+++ b/include/phtree/common/flat_array_map.h
@@ -30,6 +30,7 @@
  * PH-Tree.
  */
 namespace improbable::phtree {
+using namespace detail;
 
 template <typename Key, typename Value, Key SIZE>
 class flat_array_map;

--- a/include/phtree/common/flat_sparse_map.h
+++ b/include/phtree/common/flat_sparse_map.h
@@ -29,6 +29,7 @@
  * the PH-Tree.
  */
 namespace improbable::phtree {
+using namespace detail;
 
 /*
  * The sparse_map is a flat map implementation that uses an array of *at* *most* SIZE=2^DIM.

--- a/include/phtree/common/tree_stats.h
+++ b/include/phtree/common/tree_stats.h
@@ -28,6 +28,7 @@
  * They provide various statistics on the PH-Tree instance that returns them.
  */
 namespace improbable::phtree {
+using namespace detail;
 
 class PhTreeStats {
     using SCALAR = scalar_64_t;

--- a/test/common/bits_test.cc
+++ b/test/common/bits_test.cc
@@ -19,6 +19,7 @@
 #include <random>
 
 using namespace improbable::phtree;
+using namespace detail;
 
 TEST(PhTreeBitsTest, CountLeadingZeros64) {
     std::uint64_t x = 1;


### PR DESCRIPTION
Move some stuff in `common` into `namespace detail`. See #129 .