### PR TITLE
Move B+tree into namespace and remove using namespace from any headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Moved some stuff in `common` into `nemaspace detail`. [#129](https://github.com/tzaeschke/phtree-cpp/issues/129)
-  and [#131](https://github.com/tzaeschke/phtree-cpp/pull/131)
+- Moved B+trees into own namespace. [#131](https://github.com/tzaeschke/phtree-cpp/pull/131)
 
 ## [1.5.0] - 2023-02-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Moved some stuff in `common` into `nemaspace detail`. [#129](https://github.com/tzaeschke/phtree-cpp/issues/129)
+  and [#131](https://github.com/tzaeschke/phtree-cpp/pull/131)
 
 ## [1.5.0] - 2023-02-09
 ### Added

--- a/benchmark/benchmark_util.h
+++ b/benchmark/benchmark_util.h
@@ -23,8 +23,6 @@
 
 namespace improbable::phtree::phbenchmark {
 
-using namespace improbable::phtree;
-
 namespace {
 template <dimension_t DIM>
 auto CreateDataCUBE = [](auto& points,
@@ -102,12 +100,13 @@ auto CreatePointDataMinMax = [](auto& points,
                                 double world_maximum,
                                 double fraction_of_duplicates) {
     auto set_coordinate_lambda = [](auto& p, dimension_t dim, auto value) {
-        p[dim] = static_cast < typename std::remove_reference_t<decltype(p[0])>>(value);
+        p[dim] = static_cast<typename std::remove_reference_t<decltype(p[0])>>(value);
     };
     // Create at least 1 unique point
     // Note that the following point generator is likely, but not guaranteed, to created unique
     // points.
-    int num_unique_entries = static_cast<int>(1 + (num_entities - 1) * (1. - fraction_of_duplicates));
+    int num_unique_entries =
+        static_cast<int>(1 + static_cast<double>(num_entities - 1) * (1. - fraction_of_duplicates));
     points.reserve(num_entities);
     switch (test_generator) {
     case CUBE:
@@ -142,7 +141,8 @@ auto CreateBoxDataMinMax = [](auto& points,
     // Create at least 1 unique point
     // Note that the following point generator is likely, but not guaranteed, to created unique
     // points.
-    int num_unique_entries = static_cast<int>(1 + (num_entities - 1) * (1. - fraction_of_duplicates));
+    int num_unique_entries =
+        static_cast<int>(1 + static_cast<double>(num_entities - 1) * (1. - fraction_of_duplicates));
     points.reserve(num_entities);
     switch (test_generator) {
     case CUBE:

--- a/benchmark/benchmark_util.h
+++ b/benchmark/benchmark_util.h
@@ -30,11 +30,11 @@ template <dimension_t DIM>
 auto CreateDataCUBE = [](auto& points,
                          size_t num_entities,
                          std::uint32_t seed,
-                         double world_mininum,
+                         double world_minimum,
                          double world_maximum,
                          auto set_coordinate) {
     std::default_random_engine random_engine{seed};
-    std::uniform_real_distribution<> distribution(world_mininum, world_maximum);
+    std::uniform_real_distribution<> distribution(world_minimum, world_maximum);
     for (size_t i = 0; i < num_entities; ++i) {
         auto& p = points[i];
         for (dimension_t d = 0; d < DIM; ++d) {

--- a/benchmark/bit_ops_benchmark.cc
+++ b/benchmark/bit_ops_benchmark.cc
@@ -17,8 +17,8 @@
 #include "logging.h"
 #include <benchmark/benchmark.h>
 
-using namespace improbable;
 using namespace improbable::phtree;
+using namespace improbable::phtree::detail;
 using namespace improbable::phtree::phbenchmark;
 
 namespace {

--- a/benchmark/bit_ops_benchmark.cc
+++ b/benchmark/bit_ops_benchmark.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Improbable Worlds Limited
+* Copyright 2022-2023 Tilmann Zäschke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/bpt_erase_it_benchmark.cc
+++ b/benchmark/bpt_erase_it_benchmark.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Tilmann Zäschke
+* Copyright 2022-2023 Tilmann Zäschke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,8 @@
 #include "phtree/common/b_plus_tree_multimap.h"
 #include <benchmark/benchmark.h>
 
-using namespace improbable;
-using namespace improbable::phtree;
 using namespace improbable::phtree::phbenchmark;
+using namespace phtree::bptree;
 
 namespace {
 
@@ -38,6 +37,8 @@ enum Scenario {
 
 using payload_t = int;
 using key_t = uint32_t;
+template <size_t DIM>
+using TestPoint = std::array<double, DIM>;
 
 template <Scenario SCENARIO, size_t MAX_SIZE>
 using TestIndex = typename std::conditional_t<
@@ -60,7 +61,7 @@ using TestIndex = typename std::conditional_t<
 /*
  * Benchmark for removing entries.
  */
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 class IndexBenchmark {
     using Index = TestIndex<TYPE, (1 << DIM)>;
 
@@ -79,10 +80,10 @@ class IndexBenchmark {
 
     std::default_random_engine random_engine_;
     std::uniform_int_distribution<> cube_distribution_;
-    std::vector<PhPoint<1>> points_;
+    std::vector<TestPoint<1>> points_;
 };
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fraction_of_duplicates)
 : data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
@@ -94,7 +95,7 @@ IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fracti
     SetupWorld(state);
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::Benchmark(benchmark::State& state) {
     for (auto _ : state) {
         state.PauseTiming();
@@ -111,7 +112,7 @@ void IndexBenchmark<DIM, TYPE>::Benchmark(benchmark::State& state) {
     }
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("Creating {} entities with DIM={}.", num_entities_, 1);
     CreatePointData<1>(points_, data_type_, num_entities_, 0, GLOBAL_MAX, fraction_of_duplicates_);
@@ -121,18 +122,18 @@ void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("World setup complete.");
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::Insert(benchmark::State&, Index& tree) {
     for (size_t i = 0; i < num_entities_; ++i) {
         tree.emplace(points_[i][0], (payload_t)i);
     }
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::Remove(benchmark::State& state, Index& tree) {
     size_t n = 0;
     for (size_t i = 0; i < num_entities_; ++i) {
-       auto iter = tree.find(points_[i][0]);
+        auto iter = tree.find(points_[i][0]);
         if (iter != tree.end()) {
             tree.erase(iter);
             ++n;

--- a/benchmark/bpt_insert_benchmark.cc
+++ b/benchmark/bpt_insert_benchmark.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Improbable Worlds Limited
+* Copyright 2022-2023 Tilmann Zäschke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,8 @@
 #include "phtree/common/b_plus_tree_multimap.h"
 #include <benchmark/benchmark.h>
 
-using namespace improbable;
-using namespace improbable::phtree;
 using namespace improbable::phtree::phbenchmark;
+using namespace phtree::bptree;
 
 namespace {
 
@@ -38,6 +37,8 @@ enum Scenario {
 
 using payload_t = int;
 using key_t = uint32_t;
+template <size_t DIM>
+using TestPoint = std::array<double, DIM>;
 
 template <Scenario SCENARIO, size_t MAX_SIZE>
 using TestIndex = typename std::conditional_t<
@@ -60,7 +61,7 @@ using TestIndex = typename std::conditional_t<
 /*
  * Benchmark for adding entries to the index.
  */
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 class IndexBenchmark {
     using Index = TestIndex<TYPE, (1 << DIM)>;
 
@@ -75,10 +76,10 @@ class IndexBenchmark {
     const TestGenerator data_type_;
     const size_t num_entities_;
     const double fraction_of_duplicates_;
-    std::vector<PhPoint<1>> points_;
+    std::vector<TestPoint<1>> points_;
 };
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fraction_of_duplicates)
 : data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
@@ -88,7 +89,7 @@ IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fracti
     SetupWorld(state);
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::Benchmark(benchmark::State& state) {
     for (auto _ : state) {
         state.PauseTiming();
@@ -104,7 +105,7 @@ void IndexBenchmark<DIM, TYPE>::Benchmark(benchmark::State& state) {
     }
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("Creating {} entities with DIM={}.", num_entities_, 1);
     CreatePointData<1>(points_, data_type_, num_entities_, 0, GLOBAL_MAX, fraction_of_duplicates_);
@@ -114,7 +115,7 @@ void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("World setup complete.");
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::Insert(benchmark::State& state, Index& tree) {
     switch (TYPE) {
     default: {

--- a/benchmark/bpt_iter_benchmark.cc
+++ b/benchmark/bpt_iter_benchmark.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Tilmann Zäschke
+* Copyright 2022-2023 Tilmann Zäschke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,8 @@
 #include "phtree/common/b_plus_tree_multimap.h"
 #include <benchmark/benchmark.h>
 
-using namespace improbable;
-using namespace improbable::phtree;
 using namespace improbable::phtree::phbenchmark;
+using namespace phtree::bptree;
 
 namespace {
 
@@ -38,6 +37,8 @@ enum Scenario {
 
 using payload_t = int;
 using key_t = uint32_t;
+template <size_t DIM>
+using TestPoint = std::array<double, DIM>;
 
 template <Scenario SCENARIO, size_t MAX_SIZE>
 using TestIndex = typename std::conditional_t<
@@ -60,7 +61,7 @@ using TestIndex = typename std::conditional_t<
 /*
  * Benchmark for window queries.
  */
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 class IndexBenchmark {
     using Index = TestIndex<TYPE, (1 << DIM)>;
 
@@ -79,10 +80,10 @@ class IndexBenchmark {
     Index tree_;
     std::default_random_engine random_engine_;
     std::uniform_int_distribution<> cube_distribution_;
-    std::vector<PhPoint<1>> points_;
+    std::vector<TestPoint<1>> points_;
 };
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fraction_of_duplicates)
 : data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
@@ -95,14 +96,14 @@ IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fracti
     SetupWorld(state);
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::Benchmark(benchmark::State& state) {
     for (auto _ : state) {
         QueryWorld(state);
     }
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("Creating {} entities with DIM={}.", num_entities_, 1);
     CreatePointData<1>(points_, data_type_, num_entities_, 0, GLOBAL_MAX, fraction_of_duplicates_);
@@ -116,7 +117,7 @@ void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("World setup complete.");
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::QueryWorld(benchmark::State& state) {
     size_t n = 0;
     for (auto q = tree_.begin(); q != tree_.end(); ++q) {

--- a/benchmark/bpt_lower_bound_benchmark.cc
+++ b/benchmark/bpt_lower_bound_benchmark.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Improbable Worlds Limited
+ * Copyright 2022-2023 Tilmann Zäschke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,8 @@
 #include <benchmark/benchmark.h>
 #include <random>
 
-using namespace improbable;
-using namespace improbable::phtree;
 using namespace improbable::phtree::phbenchmark;
+using namespace phtree::bptree;
 
 namespace {
 
@@ -39,6 +38,8 @@ enum Scenario {
 
 using payload_t = int;
 using key_t = uint32_t;
+template <size_t DIM>
+using TestPoint = std::array<double, DIM>;
 
 template <Scenario SCENARIO, size_t MAX_SIZE>
 using TestIndex = typename std::conditional_t<
@@ -61,7 +62,7 @@ using TestIndex = typename std::conditional_t<
 /*
  * Benchmark for looking up entries by their key.
  */
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 class IndexBenchmark {
     using Index = TestIndex<TYPE, (1 << DIM)>;
 
@@ -80,10 +81,10 @@ class IndexBenchmark {
     Index tree_;
     std::default_random_engine random_engine_;
     std::uniform_int_distribution<> cube_distribution_;
-    std::vector<PhPoint<1>> points_;
+    std::vector<TestPoint<1>> points_;
 };
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fraction_of_duplicates)
 : data_type_{static_cast<TestGenerator>(state.range(1))}
 , num_entities_(state.range(0))
@@ -96,7 +97,7 @@ IndexBenchmark<DIM, TYPE>::IndexBenchmark(benchmark::State& state, double fracti
     SetupWorld(state);
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::Benchmark(benchmark::State& state) {
     int num_inner = 0;
     int num_found = 0;
@@ -111,7 +112,7 @@ void IndexBenchmark<DIM, TYPE>::Benchmark(benchmark::State& state) {
     state.counters["avg_result_count"] += num_found;
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("Creating {} entities with DIM={}.", num_entities_, 1);
     CreatePointData<1>(points_, data_type_, num_entities_, 0, GLOBAL_MAX, fraction_of_duplicates_);
@@ -125,7 +126,7 @@ void IndexBenchmark<DIM, TYPE>::SetupWorld(benchmark::State& state) {
     logging::info("World setup complete.");
 }
 
-template <dimension_t DIM, Scenario TYPE>
+template <size_t DIM, Scenario TYPE>
 bool IndexBenchmark<DIM, TYPE>::QueryWorld() {
     static int pos = 0;
     pos = (pos + 1) % num_entities_;

--- a/benchmark/extent_benchmark_weird.cc
+++ b/benchmark/extent_benchmark_weird.cc
@@ -115,11 +115,11 @@ class FilterBoxIntersection {
 
     [[nodiscard]] bool IsNodeValid(const PhPoint<DIM>& prefix, int bits_to_ignore) const {
         // skip this for root node (bitsToIgnore == 64)
-        if (bits_to_ignore >= (MAX_BIT_WIDTH<SCALAR> - 1)) {
+        if (bits_to_ignore >= (detail::MAX_BIT_WIDTH<SCALAR> - 1)) {
             return true;
         }
-        bit_mask_t<SCALAR> mask_min = MAX_MASK<SCALAR> << bits_to_ignore;
-        bit_mask_t<SCALAR> mask_max = ~mask_min;
+        detail::bit_mask_t<SCALAR> mask_min = detail::MAX_MASK<SCALAR> << bits_to_ignore;
+        detail::bit_mask_t<SCALAR> mask_max = ~mask_min;
 
         for (size_t i = 0; i < prefix.size(); ++i) {
             if ((prefix[i] | mask_max) < min_include_bits[i] ||

--- a/benchmark/query_mm_d_filter_benchmark.cc
+++ b/benchmark/query_mm_d_filter_benchmark.cc
@@ -96,11 +96,11 @@ class FilterSphereLegacy {
     [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, std::uint32_t bits_to_ignore) const {
         // we always want to traverse the root node (bits_to_ignore == 64)
 
-        if (bits_to_ignore >= (MAX_BIT_WIDTH<ScalarInternal> - 1)) {
+        if (bits_to_ignore >= (detail::MAX_BIT_WIDTH<ScalarInternal> - 1)) {
             return true;
         }
 
-        ScalarInternal node_min_bits = MAX_MASK<ScalarInternal> << bits_to_ignore;
+        ScalarInternal node_min_bits = detail::MAX_MASK<ScalarInternal> << bits_to_ignore;
         ScalarInternal node_max_bits = ~node_min_bits;
 
         KeyInternal closest_in_bounds;

--- a/include/phtree/common/b_plus_tree_hash_map.h
+++ b/include/phtree/common/b_plus_tree_hash_map.h
@@ -30,7 +30,6 @@
  * the PH-Tree.
  */
 namespace improbable::phtree {
-using namespace ::phtree::bptree::detail;
 
 /*
  * The b_plus_tree_hash_map is a B+tree implementation that uses a hierarchy of horizontally
@@ -85,8 +84,8 @@ class b_plus_tree_hash_set {
     class bpt_iterator;
     using IterT = bpt_iterator;
     using NLeafT = bpt_node_leaf;
-    using NInnerT = bpt_node_inner<hash_t, NLeafT>;
-    using NodeT = bpt_node_base<hash_t, NInnerT, bpt_node_leaf>;
+    using NInnerT = ::phtree::bptree::detail::bpt_node_inner<hash_t, NLeafT>;
+    using NodeT = ::phtree::bptree::detail::bpt_node_base<hash_t, NInnerT, bpt_node_leaf>;
     using TreeT = b_plus_tree_hash_set<T, HashT, PredT>;
 
   public:
@@ -239,7 +238,8 @@ class b_plus_tree_hash_set {
     }
 
   private:
-    using bpt_leaf_super = bpt_node_data<hash_t, T, NInnerT, NLeafT, true>;
+    using bpt_leaf_super =
+        ::phtree::bptree::detail::bpt_node_data<hash_t, T, NInnerT, NLeafT, true>;
     class bpt_node_leaf : public bpt_leaf_super {
       public:
         explicit bpt_node_leaf(NInnerT* parent, NLeafT* prev, NLeafT* next) noexcept
@@ -310,8 +310,8 @@ class b_plus_tree_hash_set {
         }
     };
 
-    class bpt_iterator : public bpt_iterator_base<NLeafT, NodeT, TreeT> {
-        using SuperT = bpt_iterator_base<NLeafT, NodeT, TreeT>;
+    class bpt_iterator : public ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
+        using SuperT = ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
 
       public:
         using iterator_category = std::forward_iterator_tag;

--- a/include/phtree/common/b_plus_tree_hash_map.h
+++ b/include/phtree/common/b_plus_tree_hash_map.h
@@ -29,7 +29,7 @@
  * This file contains the B+tree implementation which is used in high-dimensional nodes in
  * the PH-Tree.
  */
-namespace improbable::phtree {
+namespace phtree::bptree {
 
 /*
  * The b_plus_tree_hash_map is a B+tree implementation that uses a hierarchy of horizontally
@@ -84,8 +84,8 @@ class b_plus_tree_hash_set {
     class bpt_iterator;
     using IterT = bpt_iterator;
     using NLeafT = bpt_node_leaf;
-    using NInnerT = ::phtree::bptree::detail::bpt_node_inner<hash_t, NLeafT>;
-    using NodeT = ::phtree::bptree::detail::bpt_node_base<hash_t, NInnerT, bpt_node_leaf>;
+    using NInnerT = detail::bpt_node_inner<hash_t, NLeafT>;
+    using NodeT = detail::bpt_node_base<hash_t, NInnerT, bpt_node_leaf>;
     using TreeT = b_plus_tree_hash_set<T, HashT, PredT>;
 
   public:
@@ -238,8 +238,7 @@ class b_plus_tree_hash_set {
     }
 
   private:
-    using bpt_leaf_super =
-        ::phtree::bptree::detail::bpt_node_data<hash_t, T, NInnerT, NLeafT, true>;
+    using bpt_leaf_super = detail::bpt_node_data<hash_t, T, NInnerT, NLeafT, true>;
     class bpt_node_leaf : public bpt_leaf_super {
       public:
         explicit bpt_node_leaf(NInnerT* parent, NLeafT* prev, NLeafT* next) noexcept
@@ -310,8 +309,8 @@ class b_plus_tree_hash_set {
         }
     };
 
-    class bpt_iterator : public ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
-        using SuperT = ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
+    class bpt_iterator : public detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
+        using SuperT = detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
 
       public:
         using iterator_category = std::forward_iterator_tag;
@@ -496,6 +495,6 @@ class b_plus_tree_hash_map {
     b_plus_tree_hash_set<EntryT, EntryHashT, EntryEqualsT> map_;
 };
 
-}  // namespace improbable::phtree
+}  // namespace phtree::bptree
 
 #endif  // PHTREE_COMMON_B_PLUS_TREE_HASH_MAP_H

--- a/include/phtree/common/b_plus_tree_map.h
+++ b/include/phtree/common/b_plus_tree_map.h
@@ -29,7 +29,7 @@
  * This file contains the B+tree implementation which is used in high-dimensional nodes in
  * the PH-Tree.
  */
-namespace improbable::phtree {
+namespace phtree::bptree {
 
 /*
  * The b_plus_tree_map is a B+tree implementation that uses a hierarchy of horizontally
@@ -82,15 +82,15 @@ class b_plus_tree_map {
     constexpr static size_t INNER_MIN = 2;  // std::max((size_t)2, M_inner >> 2);
     constexpr static size_t LEAF_INIT = std::min(size_t(2), LEAF_MAX);
     constexpr static size_t INNER_INIT = std::min(size_t(4), INNER_MAX);
-    using LEAF_CFG = ::phtree::bptree::detail::bpt_config<LEAF_MAX, LEAF_MIN, LEAF_INIT>;
-    using INNER_CFG = ::phtree::bptree::detail::bpt_config<INNER_MAX, INNER_MIN, INNER_INIT>;
+    using LEAF_CFG = detail::bpt_config<LEAF_MAX, LEAF_MIN, LEAF_INIT>;
+    using INNER_CFG = detail::bpt_config<INNER_MAX, INNER_MIN, INNER_INIT>;
 
     class bpt_node_leaf;
     class bpt_iterator;
     using IterT = bpt_iterator;
     using NLeafT = bpt_node_leaf;
-    using NInnerT = ::phtree::bptree::detail::bpt_node_inner<KeyT, NLeafT, INNER_CFG>;
-    using NodeT = ::phtree::bptree::detail::bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
+    using NInnerT = detail::bpt_node_inner<KeyT, NLeafT, INNER_CFG>;
+    using NodeT = detail::bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
     using TreeT = b_plus_tree_map<KeyT, ValueT, COUNT_MAX>;
 
   public:
@@ -290,8 +290,8 @@ class b_plus_tree_map {
         }
     };
 
-    class bpt_iterator : public ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
-        using SuperT = ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
+    class bpt_iterator : public detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
+        using SuperT = detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
 
       public:
         using iterator_category = std::forward_iterator_tag;
@@ -323,6 +323,6 @@ class b_plus_tree_map {
     NodeT* root_;
     size_t size_;
 };
-}  // namespace improbable::phtree
+}  // namespace phtree::bptree
 
 #endif  // PHTREE_COMMON_B_PLUS_TREE_H

--- a/include/phtree/common/b_plus_tree_map.h
+++ b/include/phtree/common/b_plus_tree_map.h
@@ -30,7 +30,6 @@
  * the PH-Tree.
  */
 namespace improbable::phtree {
-using namespace ::phtree::bptree::detail;
 
 /*
  * The b_plus_tree_map is a B+tree implementation that uses a hierarchy of horizontally
@@ -83,15 +82,15 @@ class b_plus_tree_map {
     constexpr static size_t INNER_MIN = 2;  // std::max((size_t)2, M_inner >> 2);
     constexpr static size_t LEAF_INIT = std::min(size_t(2), LEAF_MAX);
     constexpr static size_t INNER_INIT = std::min(size_t(4), INNER_MAX);
-    using LEAF_CFG = bpt_config<LEAF_MAX, LEAF_MIN, LEAF_INIT>;
-    using INNER_CFG = bpt_config<INNER_MAX, INNER_MIN, INNER_INIT>;
+    using LEAF_CFG = ::phtree::bptree::detail::bpt_config<LEAF_MAX, LEAF_MIN, LEAF_INIT>;
+    using INNER_CFG = ::phtree::bptree::detail::bpt_config<INNER_MAX, INNER_MIN, INNER_INIT>;
 
     class bpt_node_leaf;
     class bpt_iterator;
     using IterT = bpt_iterator;
     using NLeafT = bpt_node_leaf;
-    using NInnerT = bpt_node_inner<KeyT, NLeafT, INNER_CFG>;
-    using NodeT = bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
+    using NInnerT = ::phtree::bptree::detail::bpt_node_inner<KeyT, NLeafT, INNER_CFG>;
+    using NodeT = ::phtree::bptree::detail::bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
     using TreeT = b_plus_tree_map<KeyT, ValueT, COUNT_MAX>;
 
   public:
@@ -233,7 +232,8 @@ class b_plus_tree_map {
     }
 
   private:
-    using bpt_leaf_super = bpt_node_data<KeyT, ValueT, NInnerT, NLeafT, true, LEAF_CFG>;
+    using bpt_leaf_super =
+        ::phtree::bptree::detail::bpt_node_data<KeyT, ValueT, NInnerT, NLeafT, true, LEAF_CFG>;
     class bpt_node_leaf : public bpt_leaf_super {
       public:
         explicit bpt_node_leaf(NInnerT* parent, NLeafT* prev, NLeafT* next) noexcept
@@ -290,8 +290,8 @@ class b_plus_tree_map {
         }
     };
 
-    class bpt_iterator : public bpt_iterator_base<NLeafT, NodeT, TreeT> {
-        using SuperT = bpt_iterator_base<NLeafT, NodeT, TreeT>;
+    class bpt_iterator : public ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
+        using SuperT = ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
 
       public:
         using iterator_category = std::forward_iterator_tag;

--- a/include/phtree/common/b_plus_tree_multimap.h
+++ b/include/phtree/common/b_plus_tree_multimap.h
@@ -29,7 +29,7 @@
  * This file contains the B+tree multimap implementation which is used in high-dimensional nodes in
  * the PH-Tree.
  */
-namespace improbable::phtree {
+namespace phtree::bptree {
 
 /*
  * The b_plus_tree_multimap is a B+tree implementation that uses a hierarchy of horizontally
@@ -82,8 +82,8 @@ class b_plus_tree_multimap {
     class bpt_iterator;
     using IterT = bpt_iterator;
     using NLeafT = bpt_node_leaf;
-    using NInnerT = ::phtree::bptree::detail::bpt_node_inner<KeyT, NLeafT>;
-    using NodeT = ::phtree::bptree::detail::bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
+    using NInnerT = detail::bpt_node_inner<KeyT, NLeafT>;
+    using NodeT = detail::bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
     using TreeT = b_plus_tree_multimap<KeyT, ValueT>;
 
   public:
@@ -272,8 +272,7 @@ class b_plus_tree_multimap {
     }
 
   private:
-    using bpt_leaf_super =
-        ::phtree::bptree::detail::bpt_node_data<KeyT, ValueT, NInnerT, NLeafT, true>;
+    using bpt_leaf_super = detail::bpt_node_data<KeyT, ValueT, NInnerT, NLeafT, true>;
     class bpt_node_leaf : public bpt_leaf_super {
       public:
         explicit bpt_node_leaf(NInnerT* parent, NLeafT* prev, NLeafT* next) noexcept
@@ -314,8 +313,8 @@ class b_plus_tree_multimap {
         }
     };
 
-    class bpt_iterator : public ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
-        using SuperT = ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
+    class bpt_iterator : public detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
+        using SuperT = detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
 
       public:
         using iterator_category = std::forward_iterator_tag;
@@ -347,6 +346,6 @@ class b_plus_tree_multimap {
     NodeT* root_;
     size_t size_;
 };
-}  // namespace improbable::phtree
+}  // namespace phtree::bptree
 
 #endif  // PHTREE_COMMON_B_PLUS_TREE_MULTIMAP_H

--- a/include/phtree/common/b_plus_tree_multimap.h
+++ b/include/phtree/common/b_plus_tree_multimap.h
@@ -30,7 +30,6 @@
  * the PH-Tree.
  */
 namespace improbable::phtree {
-using namespace ::phtree::bptree::detail;
 
 /*
  * The b_plus_tree_multimap is a B+tree implementation that uses a hierarchy of horizontally
@@ -83,8 +82,8 @@ class b_plus_tree_multimap {
     class bpt_iterator;
     using IterT = bpt_iterator;
     using NLeafT = bpt_node_leaf;
-    using NInnerT = bpt_node_inner<KeyT, NLeafT>;
-    using NodeT = bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
+    using NInnerT = ::phtree::bptree::detail::bpt_node_inner<KeyT, NLeafT>;
+    using NodeT = ::phtree::bptree::detail::bpt_node_base<KeyT, NInnerT, bpt_node_leaf>;
     using TreeT = b_plus_tree_multimap<KeyT, ValueT>;
 
   public:
@@ -273,7 +272,8 @@ class b_plus_tree_multimap {
     }
 
   private:
-    using bpt_leaf_super = bpt_node_data<KeyT, ValueT, NInnerT, NLeafT, true>;
+    using bpt_leaf_super =
+        ::phtree::bptree::detail::bpt_node_data<KeyT, ValueT, NInnerT, NLeafT, true>;
     class bpt_node_leaf : public bpt_leaf_super {
       public:
         explicit bpt_node_leaf(NInnerT* parent, NLeafT* prev, NLeafT* next) noexcept
@@ -314,8 +314,8 @@ class b_plus_tree_multimap {
         }
     };
 
-    class bpt_iterator : public bpt_iterator_base<NLeafT, NodeT, TreeT> {
-        using SuperT = bpt_iterator_base<NLeafT, NodeT, TreeT>;
+    class bpt_iterator : public ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT> {
+        using SuperT = ::phtree::bptree::detail::bpt_iterator_base<NLeafT, NodeT, TreeT>;
 
       public:
         using iterator_category = std::forward_iterator_tag;

--- a/include/phtree/common/common.h
+++ b/include/phtree/common/common.h
@@ -17,7 +17,6 @@
 #ifndef PHTREE_COMMON_COMMON_H
 #define PHTREE_COMMON_COMMON_H
 
-#include "b_plus_tree_map.h"
 #include "base_types.h"
 #include "bits.h"
 #include "flat_array_map.h"

--- a/include/phtree/common/flat_array_map.h
+++ b/include/phtree/common/flat_array_map.h
@@ -29,13 +29,12 @@
  * This file contains the array_map implementation, which is used in low-dimensional nodes in the
  * PH-Tree.
  */
-namespace improbable::phtree {
-using namespace detail;
+namespace improbable::phtree::detail {
 
 template <typename Key, typename Value, Key SIZE>
 class flat_array_map;
 
-namespace detail {
+namespace {
 
 template <typename Key, typename Value>
 using flat_map_pair = std::pair<Key, Value>;

--- a/include/phtree/common/flat_sparse_map.h
+++ b/include/phtree/common/flat_sparse_map.h
@@ -28,8 +28,7 @@
  * This file contains the sparse_map implementation, which is used in medium-dimensional nodes in
  * the PH-Tree.
  */
-namespace improbable::phtree {
-using namespace detail;
+namespace improbable::phtree::detail {
 
 /*
  * The sparse_map is a flat map implementation that uses an array of *at* *most* SIZE=2^DIM.

--- a/include/phtree/common/tree_stats.h
+++ b/include/phtree/common/tree_stats.h
@@ -28,7 +28,6 @@
  * They provide various statistics on the PH-Tree instance that returns them.
  */
 namespace improbable::phtree {
-using namespace detail;
 
 class PhTreeStats {
     using SCALAR = scalar_64_t;
@@ -40,7 +39,8 @@ class PhTreeStats {
         s << "  avgNodeDepth = " << ((double)q_total_depth_ / (double)n_nodes_) << std::endl;
         s << "  AHC=" << n_AHC_ << "  NI=" << n_nt_ << "  nNtNodes_=" << n_nt_nodes_ << std::endl;
         double apl = GetAvgPostlen();
-        s << "  avgPostLen = " << apl << " (" << (MAX_BIT_WIDTH<SCALAR> - apl) << ")" << std::endl;
+        s << "  avgPostLen = " << apl << " (" << (detail::MAX_BIT_WIDTH<SCALAR> - apl) << ")"
+          << std::endl;
         return s.str();
     }
 
@@ -63,8 +63,8 @@ class PhTreeStats {
     double GetAvgPostlen() {
         size_t total = 0;
         size_t num_entry = 0;
-        for (bit_width_t i = 0; i < MAX_BIT_WIDTH<SCALAR>; ++i) {
-            total += (MAX_BIT_WIDTH<SCALAR> - i) * q_n_post_fix_n_[i];
+        for (detail::bit_width_t i = 0; i < detail::MAX_BIT_WIDTH<SCALAR>; ++i) {
+            total += (detail::MAX_BIT_WIDTH<SCALAR> - i) * q_n_post_fix_n_[i];
             num_entry += q_n_post_fix_n_[i];
         }
         return (double)total / (double)num_entry;
@@ -96,12 +96,14 @@ class PhTreeStats {
     size_t n_total_children_ = 0;
     size_t size_ = 0;  // calculated size in bytes
     size_t q_total_depth_ = 0;
-    std::vector<size_t> q_n_post_fix_n_ =
-        std::vector(MAX_BIT_WIDTH<SCALAR>, (size_t)0);  // filled with  x[current_depth] = nPost;
-    std::vector<size_t> infix_hist_ = std::vector(MAX_BIT_WIDTH<SCALAR>, (size_t)0);  // prefix len
-    std::vector<size_t> node_depth_hist_ =
-        std::vector(MAX_BIT_WIDTH<SCALAR>, (size_t)0);                     // prefix len
-    std::vector<size_t> node_size_log_hist_ = std::vector(32, (size_t)0);  // log (num_entries)
+    // filled with  x[current_depth] = nPost;
+    std::vector<size_t> q_n_post_fix_n_ = std::vector(detail::MAX_BIT_WIDTH<SCALAR>, (size_t)0);
+    // prefix len
+    std::vector<size_t> infix_hist_ = std::vector(detail::MAX_BIT_WIDTH<SCALAR>, (size_t)0);
+    // prefix len
+    std::vector<size_t> node_depth_hist_ = std::vector(detail::MAX_BIT_WIDTH<SCALAR>, (size_t)0);
+    // log (num_entries)
+    std::vector<size_t> node_size_log_hist_ = std::vector(32, (size_t)0);
 };
 
 }  // namespace improbable::phtree

--- a/include/phtree/filter.h
+++ b/include/phtree/filter.h
@@ -139,10 +139,10 @@ class FilterAABB {
 
     [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, std::uint32_t bits_to_ignore) const {
         // Let's assume that we always want to traverse the root node (bits_to_ignore == 64)
-        if (bits_to_ignore >= (MAX_BIT_WIDTH<ScalarInternal> - 1)) {
+        if (bits_to_ignore >= (detail::MAX_BIT_WIDTH<ScalarInternal> - 1)) {
             return true;
         }
-        ScalarInternal node_min_bits = MAX_MASK<ScalarInternal> << bits_to_ignore;
+        ScalarInternal node_min_bits = detail::MAX_MASK<ScalarInternal> << bits_to_ignore;
         ScalarInternal node_max_bits = ~node_min_bits;
 
         for (dimension_t i = 0; i < DIM; ++i) {
@@ -198,11 +198,11 @@ class FilterSphere {
     [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, std::uint32_t bits_to_ignore) const {
         // we always want to traverse the root node (bits_to_ignore == 64)
 
-        if (bits_to_ignore >= (MAX_BIT_WIDTH<ScalarInternal> - 1)) {
+        if (bits_to_ignore >= (detail::MAX_BIT_WIDTH<ScalarInternal> - 1)) {
             return true;
         }
 
-        ScalarInternal node_min_bits = MAX_MASK<ScalarInternal> << bits_to_ignore;
+        ScalarInternal node_min_bits = detail::MAX_MASK<ScalarInternal> << bits_to_ignore;
         ScalarInternal node_max_bits = ~node_min_bits;
 
         KeyInternal closest_in_bounds;
@@ -272,10 +272,10 @@ class FilterBoxAABB {
 
     [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, std::uint32_t bits_to_ignore) const {
         // Let's assume that we always want to traverse the root node (bits_to_ignore == 64)
-        if (bits_to_ignore >= (MAX_BIT_WIDTH<ScalarInternal> - 1)) {
+        if (bits_to_ignore >= (detail::MAX_BIT_WIDTH<ScalarInternal> - 1)) {
             return true;
         }
-        ScalarInternal node_min_bits = MAX_MASK<ScalarInternal> << bits_to_ignore;
+        ScalarInternal node_min_bits = detail::MAX_MASK<ScalarInternal> << bits_to_ignore;
         ScalarInternal node_max_bits = ~node_min_bits;
 
         for (dimension_t i = 0; i < DIM; ++i) {
@@ -334,11 +334,11 @@ class FilterBoxSphere {
     [[nodiscard]] bool IsNodeValid(const KeyInternal& prefix, std::uint32_t bits_to_ignore) const {
         // we always want to traverse the root node (bits_to_ignore == 64)
 
-        if (bits_to_ignore >= (MAX_BIT_WIDTH<ScalarInternal> - 1)) {
+        if (bits_to_ignore >= (detail::MAX_BIT_WIDTH<ScalarInternal> - 1)) {
             return true;
         }
 
-        ScalarInternal node_min_bits = MAX_MASK<ScalarInternal> << bits_to_ignore;
+        ScalarInternal node_min_bits = detail::MAX_MASK<ScalarInternal> << bits_to_ignore;
         ScalarInternal node_max_bits = ~node_min_bits;
 
         QueryPointInternal closest_in_bounds;

--- a/include/phtree/phtree.h
+++ b/include/phtree/phtree.h
@@ -31,6 +31,7 @@ namespace improbable::phtree {
  */
 template <dimension_t DIM, typename T, typename CONVERTER = ConverterNoOp<DIM, scalar_64_t>>
 class PhTree {
+    //bit_width_t t;
     friend PhTreeDebugHelper;
     using Key = typename CONVERTER::KeyExternal;
     static constexpr dimension_t DimInternal = CONVERTER::DimInternal;

--- a/include/phtree/phtree_multimap.h
+++ b/include/phtree/phtree_multimap.h
@@ -181,6 +181,9 @@ class IteratorKnn : public IteratorNormal<ITERATOR_PH, PHTREE> {
 
 }  // namespace
 
+template <typename T, typename HashT = std::hash<T>, typename EqualT = std::equal_to<T>>
+using b_plus_tree_hash_set = ::phtree::bptree::b_plus_tree_hash_set<T, HashT, EqualT>;
+
 /*
  * The PhTreeMultiMap class.
  */

--- a/include/phtree/v16/debug_helper_v16.h
+++ b/include/phtree/v16/debug_helper_v16.h
@@ -56,7 +56,7 @@ class DebugHelperV16 : public PhTreeDebugHelper::DebugHelper {
             ToStringPlain(os, root_);
             break;
         case Enum::tree:
-            ToStringTree(os, 0, root_, MAX_BIT_WIDTH<SCALAR>, true);
+            ToStringTree(os, 0, root_, detail::MAX_BIT_WIDTH<SCALAR>, true);
             break;
         }
         return os.str();
@@ -96,12 +96,12 @@ class DebugHelperV16 : public PhTreeDebugHelper::DebugHelper {
 
     void ToStringTree(
         std::ostringstream& sb,
-        bit_width_t current_depth,
+        detail::bit_width_t current_depth,
         const EntryT& entry,
-        const bit_width_t parent_postfix_len,
+        const detail::bit_width_t parent_postfix_len,
         bool print_value) const {
         std::string ind = "*";
-        for (bit_width_t i = 0; i < current_depth; ++i) {
+        for (detail::bit_width_t i = 0; i < current_depth; ++i) {
             ind += "-";
         }
         const auto& node = entry.GetNode();
@@ -112,11 +112,11 @@ class DebugHelperV16 : public PhTreeDebugHelper::DebugHelper {
 
         // for a leaf node, the existence of a sub just indicates that the value exists.
         if (infix_len > 0) {
-            bit_mask_t<SCALAR> mask = MAX_MASK<SCALAR> << infix_len;
+            detail::bit_mask_t<SCALAR> mask = detail::MAX_MASK<SCALAR> << infix_len;
             mask = ~mask;
             mask <<= (std::uint64_t)postfix_len + 1;
             for (dimension_t i = 0; i < DIM; ++i) {
-                sb << ToBinary<SCALAR>(entry.GetKey()[i] & mask) << ",";
+                sb << detail::ToBinary<SCALAR>(entry.GetKey()[i] & mask) << ",";
             }
         }
         current_depth += infix_len;
@@ -133,7 +133,7 @@ class DebugHelperV16 : public PhTreeDebugHelper::DebugHelper {
                 ToStringTree(sb, current_depth + 1, child, postfix_len, print_value);
             } else {
                 // post-fix
-                sb << ind << ToBinary(child.GetKey());
+                sb << ind << detail::ToBinary(child.GetKey());
                 sb << "  hcPos=" << hc_pos;
                 if (print_value) {
                     sb << "  v=" << (child.IsValue() ? "T" : "null");

--- a/include/phtree/v16/entry.h
+++ b/include/phtree/v16/entry.h
@@ -36,6 +36,7 @@ class Node;
  */
 template <dimension_t DIM, typename T, typename SCALAR>
 class Entry {
+    using bit_width_t = detail::bit_width_t;
     using KeyT = PhPoint<DIM, SCALAR>;
     using ValueT = std::remove_const_t<T>;
     using NodeT = Node<DIM, T, SCALAR>;
@@ -131,10 +132,10 @@ class Entry {
         // This is required for window queries which would otherwise need to calculate the
         // center each time they traverse a node.
         assert(union_type_ == NODE);
-        bit_mask_t<SCALAR> maskHcBit = bit_mask_t<SCALAR>(1) << postfix_len_;
-        bit_mask_t<SCALAR> maskVT = MAX_MASK<SCALAR> << postfix_len_;
+        detail::bit_mask_t<SCALAR> maskHcBit = detail::bit_mask_t<SCALAR>(1) << postfix_len_;
+        detail::bit_mask_t<SCALAR> maskVT = detail::MAX_MASK<SCALAR> << postfix_len_;
         // to prevent problems with signed long when using 64 bit
-        if (postfix_len_ < MAX_BIT_WIDTH<SCALAR> - 1) {
+        if (postfix_len_ < detail::MAX_BIT_WIDTH<SCALAR> - 1) {
             for (dimension_t i = 0; i < DIM; ++i) {
                 kd_key_[i] = (kd_key_[i] | maskHcBit) & maskVT;
             }

--- a/include/phtree/v16/for_each_hc.h
+++ b/include/phtree/v16/for_each_hc.h
@@ -22,7 +22,6 @@
 #include "phtree/common/common.h"
 
 namespace improbable::phtree::v16 {
-using namespace detail;
 
 /*
  * The HC (hyper cube) iterator uses `hypercube navigation`, ie. filtering of quadrants by their
@@ -41,7 +40,7 @@ class ForEachHC {
     using KeyInternal = typename CONVERT::KeyInternal;
     using SCALAR = typename CONVERT::ScalarInternal;
     using EntryT = Entry<DIM, T, SCALAR>;
-    using hc_pos_t = hc_pos_dim_t<DIM>;
+    using hc_pos_t = detail::hc_pos_dim_t<DIM>;
 
   public:
     template <typename CB, typename F>
@@ -61,7 +60,7 @@ class ForEachHC {
         assert(entry.IsNode());
         hc_pos_t mask_lower = 0;
         hc_pos_t mask_upper = 0;
-        CalcLimits(entry.GetNodePostfixLen(), min_, max_, entry.GetKey(), mask_lower, mask_upper);
+        detail::CalcLimits(entry.GetNodePostfixLen(), min_, max_, entry.GetKey(), mask_lower, mask_upper);
         auto& entries = entry.GetNode().Entries();
         auto postfix_len = entry.GetNodePostfixLen();
         auto end = entries.end();
@@ -79,7 +78,7 @@ class ForEachHC {
                     }
                 } else {
                     T& value = child.GetValue();
-                    if (IsInRange(child_key, min_, max_) &&
+                    if (detail::IsInRange(child_key, min_, max_) &&
                         filter_.IsEntryValid(child_key, value)) {
                         callback_(converter_->post(child_key), value);
                     }
@@ -89,7 +88,7 @@ class ForEachHC {
     }
 
   private:
-    bool CheckNode(const EntryT& entry, bit_width_t parent_postfix_len) {
+    bool CheckNode(const EntryT& entry, detail::bit_width_t parent_postfix_len) {
         const KeyInternal& key = entry.GetKey();
         // Check if the node overlaps with the query box.
         // An infix with len=0 implies that at least part of the child node overlaps with the query,
@@ -98,8 +97,8 @@ class ForEachHC {
         bool mismatch = false;
         if (entry.HasNodeInfix(parent_postfix_len)) {
             // Mask for comparing the prefix with the query boundaries.
-            assert(entry.GetNodePostfixLen() + 1 < MAX_BIT_WIDTH<SCALAR>);
-            SCALAR comparison_mask = MAX_MASK<SCALAR> << (entry.GetNodePostfixLen() + 1);
+            assert(entry.GetNodePostfixLen() + 1 < detail::MAX_BIT_WIDTH<SCALAR>);
+            SCALAR comparison_mask = detail::MAX_MASK<SCALAR> << (entry.GetNodePostfixLen() + 1);
             for (dimension_t dim = 0; dim < DIM; ++dim) {
                 SCALAR prefix = key[dim] & comparison_mask;
                 mismatch |= (prefix > max_[dim] || prefix < (min_[dim] & comparison_mask));

--- a/include/phtree/v16/iterator_full.h
+++ b/include/phtree/v16/iterator_full.h
@@ -106,7 +106,7 @@ class IteratorFull : public IteratorWithFilter<T, CONVERT, FILTER> {
 
     std::array<
         std::pair<EntryIteratorC<DIM, EntryT>, EntryIteratorC<DIM, EntryT>>,
-        MAX_BIT_WIDTH<SCALAR>>
+        detail::MAX_BIT_WIDTH<SCALAR>>
         stack_;
     size_t stack_size_;
 };

--- a/include/phtree/v16/iterator_hc.h
+++ b/include/phtree/v16/iterator_hc.h
@@ -22,7 +22,6 @@
 #include "phtree/common/common.h"
 
 namespace improbable::phtree::v16 {
-using namespace detail;
 
 template <dimension_t DIM, typename T, typename SCALAR>
 class Node;
@@ -136,14 +135,15 @@ class NodeIterator {
     using KeyT = PhPoint<DIM, SCALAR>;
     using EntryT = Entry<DIM, T, SCALAR>;
     using EntriesT = const EntryMap<DIM, EntryT>;
-    using hc_pos_t = hc_pos_dim_t<DIM>;
+    using hc_pos_t = detail::hc_pos_dim_t<DIM>;
 
   public:
     NodeIterator() : iter_{}, entries_{nullptr}, mask_lower_{0}, mask_upper_{0}, postfix_len_{0} {}
 
     void Init(const KeyT& min, const KeyT& max, const EntryT& entry) {
         auto& node = entry.GetNode();
-        CalcLimits(entry.GetNodePostfixLen(), min, max, entry.GetKey(), mask_lower_, mask_upper_);
+        detail::CalcLimits(
+            entry.GetNodePostfixLen(), min, max, entry.GetKey(), mask_lower_, mask_upper_);
         iter_ = node.Entries().lower_bound(mask_lower_);
         entries_ = &node.Entries();
         postfix_len_ = entry.GetNodePostfixLen();
@@ -169,7 +169,7 @@ class NodeIterator {
 
     bool CheckEntry(const EntryT& candidate, const KeyT& range_min, const KeyT& range_max) const {
         if (candidate.IsValue()) {
-            return IsInRange(candidate.GetKey(), range_min, range_max);
+            return detail::IsInRange(candidate.GetKey(), range_min, range_max);
         }
 
         // Check if node-prefix allows sub-node to contain any useful values.
@@ -180,8 +180,8 @@ class NodeIterator {
         }
 
         // Mask for comparing the prefix with the query boundaries.
-        assert(candidate.GetNodePostfixLen() + 1 < MAX_BIT_WIDTH<SCALAR>);
-        SCALAR comparison_mask = MAX_MASK<SCALAR> << (candidate.GetNodePostfixLen() + 1);
+        assert(candidate.GetNodePostfixLen() + 1 < detail::MAX_BIT_WIDTH<SCALAR>);
+        SCALAR comparison_mask = detail::MAX_MASK<SCALAR> << (candidate.GetNodePostfixLen() + 1);
         auto& key = candidate.GetKey();
         for (dimension_t dim = 0; dim < DIM; ++dim) {
             SCALAR in = key[dim] & comparison_mask;
@@ -202,7 +202,7 @@ class NodeIterator {
     EntriesT* entries_;
     hc_pos_t mask_lower_;
     hc_pos_t mask_upper_;
-    bit_width_t postfix_len_;
+    detail::bit_width_t postfix_len_;
 };
 }  // namespace
 }  // namespace improbable::phtree::v16

--- a/include/phtree/v16/iterator_knn_hs.h
+++ b/include/phtree/v16/iterator_knn_hs.h
@@ -130,8 +130,8 @@ class IteratorKnnHS : public IteratorWithFilter<T, CONVERT, FILTER> {
     }
 
     double DistanceToNode(const KeyInternal& prefix, std::uint32_t bits_to_ignore) {
-        assert(bits_to_ignore < MAX_BIT_WIDTH<SCALAR>);
-        SCALAR mask_min = MAX_MASK<SCALAR> << bits_to_ignore;
+        assert(bits_to_ignore < detail::MAX_BIT_WIDTH<SCALAR>);
+        SCALAR mask_min = detail::MAX_MASK<SCALAR> << bits_to_ignore;
         SCALAR mask_max = ~mask_min;
         KeyInternal buf;
         // The following calculates the point inside the node that is closest to center_.

--- a/include/phtree/v16/iterator_lower_bound.h
+++ b/include/phtree/v16/iterator_lower_bound.h
@@ -166,7 +166,7 @@ class IteratorLowerBound : public IteratorWithFilter<T, CONVERT, FILTER> {
 
     std::array<
         std::pair<EntryIteratorC<DIM, EntryT>, EntryIteratorC<DIM, EntryT>>,
-        MAX_BIT_WIDTH<SCALAR>>
+        detail::MAX_BIT_WIDTH<SCALAR>>
         stack_;
     size_t stack_size_;
 };

--- a/include/phtree/v16/node.h
+++ b/include/phtree/v16/node.h
@@ -19,6 +19,7 @@
 #define PHTREE_V16_NODE_H
 
 #include "entry.h"
+#include "phtree/common/b_plus_tree_map.h"
 #include "phtree/common/common.h"
 #include "phtree_v16.h"
 #include <map>
@@ -47,7 +48,7 @@ using EntryMap = typename std::conditional_t<
     typename std::conditional_t<
         DIM <= 8,
         detail::sparse_map<detail::hc_pos_dim_t<DIM>, Entry>,
-        b_plus_tree_map<detail::hc_pos_dim_t<DIM>, Entry, (uint64_t(1) << DIM)>>>;
+        ::phtree::bptree::b_plus_tree_map<detail::hc_pos_dim_t<DIM>, Entry, (uint64_t(1) << DIM)>>>;
 
 template <dimension_t DIM, typename Entry>
 using EntryIterator = typename std::remove_const_t<decltype(EntryMap<DIM, Entry>().begin())>;

--- a/include/phtree/v16/node.h
+++ b/include/phtree/v16/node.h
@@ -43,11 +43,11 @@ template <dimension_t DIM, typename Entry>
 // using EntryMap = std::map<hc_pos_dim_t<DIM>, Entry>;
 using EntryMap = typename std::conditional_t<
     DIM <= 3,
-    array_map<hc_pos_dim_t<DIM>, Entry, (size_t(1) << DIM)>,
+    detail::array_map<detail::hc_pos_dim_t<DIM>, Entry, (size_t(1) << DIM)>,
     typename std::conditional_t<
         DIM <= 8,
-        sparse_map<hc_pos_dim_t<DIM>, Entry>,
-        b_plus_tree_map<hc_pos_dim_t<DIM>, Entry, (uint64_t(1) << DIM)>>>;
+        detail::sparse_map<detail::hc_pos_dim_t<DIM>, Entry>,
+        b_plus_tree_map<detail::hc_pos_dim_t<DIM>, Entry, (uint64_t(1) << DIM)>>>;
 
 template <dimension_t DIM, typename Entry>
 using EntryIterator = typename std::remove_const_t<decltype(EntryMap<DIM, Entry>().begin())>;
@@ -75,9 +75,10 @@ using EntryIteratorC = decltype(EntryMap<DIM, Entry>().cbegin());
  */
 template <dimension_t DIM, typename T, typename SCALAR>
 class Node {
+    using bit_width_t = detail::bit_width_t;
     using KeyT = PhPoint<DIM, SCALAR>;
     using EntryT = Entry<DIM, T, SCALAR>;
-    using hc_pos_t = hc_pos_dim_t<DIM>;
+    using hc_pos_t = detail::hc_pos_dim_t<DIM>;
 
   public:
     Node() : entries_{} {}
@@ -121,7 +122,7 @@ class Node {
      */
     template <typename... Args>
     EntryT& Emplace(bool& is_inserted, const KeyT& key, bit_width_t postfix_len, Args&&... args) {
-        hc_pos_t hc_pos = CalcPosInArray(key, postfix_len);
+        hc_pos_t hc_pos = detail::CalcPosInArray(key, postfix_len);
         auto emplace_result = entries_.try_emplace(hc_pos, key, std::forward<Args>(args)...);
         auto& entry = emplace_result.first->second;
         // Return if emplace succeed, i.e. there was no entry.
@@ -135,7 +136,8 @@ class Node {
     template <typename IterT, typename... Args>
     EntryT& Emplace(
         IterT iter, bool& is_inserted, const KeyT& key, bit_width_t postfix_len, Args&&... args) {
-        hc_pos_t hc_pos = CalcPosInArray(key, postfix_len);  // TODO pass in -> should be known!
+        hc_pos_t hc_pos =
+            detail::CalcPosInArray(key, postfix_len);  // TODO pass in -> should be known!
         if (iter == entries_.end() || iter->first != hc_pos) {
             auto emplace_result =
                 entries_.try_emplace(iter, hc_pos, key, std::forward<Args>(args)...);
@@ -154,7 +156,7 @@ class Node {
      * @return The sub node or null.
      */
     EntryT* Find(const KeyT& key, bit_width_t postfix_len) {
-        hc_pos_t hc_pos = CalcPosInArray(key, postfix_len);
+        hc_pos_t hc_pos = detail::CalcPosInArray(key, postfix_len);
         auto iter = entries_.find(hc_pos);
         if (iter != entries_.end() && DoesEntryMatch(iter->second, key, postfix_len)) {
             return &iter->second;
@@ -167,13 +169,13 @@ class Node {
     }
 
     auto LowerBound(const KeyT& key, bit_width_t postfix_len, bool& found) {
-        hc_pos_t hc_pos = CalcPosInArray(key, postfix_len);
+        hc_pos_t hc_pos = detail::CalcPosInArray(key, postfix_len);
         auto iter = entries_.lower_bound(hc_pos);
         found =
             (iter != entries_.end() && iter->first == hc_pos &&
              DoesEntryMatch(iter->second, key, postfix_len));
         if (!found && iter != entries_.end() && iter->first == hc_pos &&
-            KeyLess(iter->second.GetKey(), key)) {
+            detail::KeyLess(iter->second.GetKey(), key)) {
             // There is an entry in the same slot as key would go. However it is not equal to
             // key. We need to figure out whether "key" goes before the existing entry or not.
             ++iter;
@@ -196,7 +198,7 @@ class Node {
     auto FindPrefix(
         const KeyT& prefix, bit_width_t prefix_post_len, bit_width_t node_postfix_len) const {
         assert(prefix_post_len <= node_postfix_len);
-        hc_pos_t hc_pos = CalcPosInArray(prefix, node_postfix_len);
+        hc_pos_t hc_pos = detail::CalcPosInArray(prefix, node_postfix_len);
         const auto iter = entries_.find(hc_pos);
         if (iter == entries_.end() || iter->second.IsValue() ||
             iter->second.GetNodePostfixLen() < prefix_post_len) {
@@ -224,7 +226,7 @@ class Node {
      */
     EntryT* Erase(const KeyT& key, EntryT* parent_entry, bool allow_move_into_parent, bool& found) {
         auto postfix_len = parent_entry->GetNodePostfixLen();
-        hc_pos_t hc_pos = CalcPosInArray(key, postfix_len);
+        hc_pos_t hc_pos = detail::CalcPosInArray(key, postfix_len);
         auto it = entries_.find(hc_pos);
         if (it != entries_.end() && DoesEntryMatch(it->second, key, postfix_len)) {
             if (it->second.IsNode()) {
@@ -257,7 +259,7 @@ class Node {
 
         ++stats.n_nodes_;
         ++stats.node_depth_hist_[current_depth];
-        ++stats.node_size_log_hist_[32 - CountLeadingZeros(std::uint32_t(num_children))];
+        ++stats.node_size_log_hist_[32 - detail::CountLeadingZeros(std::uint32_t(num_children))];
         stats.n_total_children_ += num_children;
         stats.q_total_depth_ += current_depth;
 
@@ -298,7 +300,7 @@ class Node {
 
         // Check node center
         auto post_len = current_entry.GetNodePostfixLen();
-        if (post_len == MAX_BIT_WIDTH<SCALAR> - 1) {
+        if (post_len == detail::MAX_BIT_WIDTH<SCALAR> - 1) {
             for (auto d : current_entry.GetKey()) {
                 assert(d == 0);
             }
@@ -357,7 +359,7 @@ class Node {
             return entry;
         }
 
-        bit_width_t max_conflicting_bits = NumberOfDivergingBits(new_key, entry.GetKey());
+        bit_width_t max_conflicting_bits = detail::NumberOfDivergingBits(new_key, entry.GetKey());
         auto split_len = is_node ? entry.GetNodePostfixLen() + 1 : 0;
         if (max_conflicting_bits <= split_len) {
             // perfect match -> return existing
@@ -375,8 +377,8 @@ class Node {
         bit_width_t max_conflicting_bits,
         Args&&... args) {
         bit_width_t new_postfix_len = max_conflicting_bits - 1;
-        hc_pos_t pos_sub_1 = CalcPosInArray(new_key, new_postfix_len);
-        hc_pos_t pos_sub_2 = CalcPosInArray(current_entry.GetKey(), new_postfix_len);
+        hc_pos_t pos_sub_1 = detail::CalcPosInArray(new_key, new_postfix_len);
+        hc_pos_t pos_sub_2 = detail::CalcPosInArray(current_entry.GetKey(), new_postfix_len);
 
         // Move key/value into subnode
         Node new_sub_node{};
@@ -400,7 +402,7 @@ class Node {
         const EntryT& entry, const KeyT& key, const bit_width_t parent_postfix_len) const {
         if (entry.IsNode()) {
             if (entry.HasNodeInfix(parent_postfix_len)) {
-                return KeyEquals(entry.GetKey(), key, entry.GetNodePostfixLen() + 1);
+                return detail::KeyEquals(entry.GetKey(), key, entry.GetNodePostfixLen() + 1);
             }
             return true;
         }

--- a/test/common/b_plus_tree_hash_map_test.cc
+++ b/test/common/b_plus_tree_hash_map_test.cc
@@ -19,7 +19,7 @@
 #include <random>
 #include <unordered_set>
 
-using namespace improbable::phtree;
+using namespace phtree::bptree;
 
 static int default_construct_count_ = 0;
 static int construct_count_ = 0;

--- a/test/common/b_plus_tree_map_test.cc
+++ b/test/common/b_plus_tree_map_test.cc
@@ -18,7 +18,7 @@
 #include <include/gtest/gtest.h>
 #include <random>
 
-using namespace improbable::phtree;
+using namespace phtree::bptree;
 
 using KeyT = std::uint64_t;
 

--- a/test/common/b_plus_tree_multimap_test.cc
+++ b/test/common/b_plus_tree_multimap_test.cc
@@ -18,7 +18,7 @@
 #include <include/gtest/gtest.h>
 #include <random>
 
-using namespace improbable::phtree;
+using namespace phtree::bptree;
 
 static int default_construct_count_ = 0;
 static int construct_count_ = 0;

--- a/test/common/common_test.cc
+++ b/test/common/common_test.cc
@@ -19,6 +19,7 @@
 #include <include/gtest/gtest.h>
 
 using namespace improbable::phtree;
+using namespace improbable::phtree::detail;
 
 TEST(PhTreeCommonTest, NumberOfDivergingBits) {
     double d1 = -55;

--- a/test/common/flat_array_map_test.cc
+++ b/test/common/flat_array_map_test.cc
@@ -27,7 +27,7 @@ TEST(PhTreeFlatArrayMapTest, SmokeTest) {
     std::uniform_int_distribution<> cube_distribution(0, max_size - 1);
 
     for (int i = 0; i < 10; i++) {
-        array_map<size_t, size_t, max_size> test_map;
+        detail::array_map<size_t, size_t, max_size> test_map;
         std::map<size_t, size_t> reference_map;
         for (int j = 0; j < 2 * max_size; j++) {
             size_t val = cube_distribution(random_engine);
@@ -61,7 +61,7 @@ TEST(PhTreeFlatArrayMapTest, SmokeTestWithTryEmplace) {
     std::uniform_int_distribution<> cube_distribution(0, max_size - 1);
 
     for (int i = 0; i < 10; i++) {
-        array_map<size_t, size_t, max_size> test_map;
+        detail::array_map<size_t, size_t, max_size> test_map;
         std::map<size_t, size_t> reference_map;
         for (int j = 0; j < 2 * max_size; j++) {
             size_t val = cube_distribution(random_engine);
@@ -91,7 +91,7 @@ TEST(PhTreeFlatArrayMapTest, SmokeTestWithTryEmplace) {
 TEST(PhTreeFlatArrayMapTest, IteratorPostIncrementTest) {
     const int num_entries = 3;
 
-    array_map<size_t, size_t, 8> test_map;
+    detail::array_map<size_t, size_t, 8> test_map;
     for (int j = 0; j < num_entries; j++) {
         size_t val = j * 2;
         bool hasVal = test_map.find(val) != test_map.end();

--- a/test/common/flat_sparse_map_test.cc
+++ b/test/common/flat_sparse_map_test.cc
@@ -27,7 +27,7 @@ TEST(PhTreeFlatSparseMapTest, SmokeTest) {
     std::uniform_int_distribution<> cube_distribution(0, max_size - 1);
 
     for (int i = 0; i < 10; i++) {
-        sparse_map<size_t, size_t> test_map;
+        detail::sparse_map<size_t, size_t> test_map;
         std::map<size_t, size_t> reference_map;
         for (int j = 0; j < 2 * max_size; j++) {
             size_t val = cube_distribution(random_engine);
@@ -61,7 +61,7 @@ TEST(PhTreeFlatSparseMapTest, SmokeTestWithTryEmplace) {
     std::uniform_int_distribution<> cube_distribution(0, max_size - 1);
 
     for (int i = 0; i < 10; i++) {
-        sparse_map<size_t, size_t> test_map;
+        detail::sparse_map<size_t, size_t> test_map;
         std::map<size_t, size_t> reference_map;
         for (int j = 0; j < 2 * max_size; j++) {
             size_t val = cube_distribution(random_engine);


### PR DESCRIPTION
Move B+tree into namespace and remove `using namespace` from any headers.