### PR TITLE
Fix relocate() return type to be size_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Replaced deprecated `<assert.h>` imports with `<cassert>`. [#134](https://github.com/tzaeschke/phtree-cpp/pull/134)
 - Fixes undefined behavior in debug method. [#135](https://github.com/tzaeschke/phtree-cpp/pull/135)
+- API: Fixes `relocate()` return type to be `size_t`. [#136](https://github.com/tzaeschke/phtree-cpp/pull/136)
 
 ## [1.5.0] - 2023-02-09
 ### Added

--- a/include/phtree/phtree.h
+++ b/include/phtree/phtree.h
@@ -209,7 +209,7 @@ class PhTree {
      * @param new_key The new position
      * @return '1' if the 'value' was moved, otherwise '0'.
      */
-    auto relocate(const Key& old_key, const Key& new_key) {
+    size_t relocate(const Key& old_key, const Key& new_key) {
         return tree_.relocate_if(
             converter_.pre(old_key), converter_.pre(new_key), [](const T&) { return true; });
     }
@@ -224,7 +224,7 @@ class PhTree {
      * @return '1' if the 'value' was moved, otherwise '0'.
      */
     template <typename PRED>
-    auto relocate_if(const Key& old_key, const Key& new_key, PRED&& predicate) {
+    size_t relocate_if(const Key& old_key, const Key& new_key, PRED&& predicate) {
         return tree_.relocate_if(
             converter_.pre(old_key), converter_.pre(new_key), std::forward<PRED>(predicate));
     }

--- a/include/phtree/v16/phtree_v16.h
+++ b/include/phtree/v16/phtree_v16.h
@@ -347,7 +347,7 @@ class PhTreeV16 {
      *          whose second element is a bool that is true if the value was actually relocated.
      */
     template <typename PRED>
-    auto relocate_if(const KeyT& old_key, const KeyT& new_key, PRED&& pred) {
+    size_t relocate_if(const KeyT& old_key, const KeyT& new_key, PRED&& pred) {
         bit_width_t n_diverging_bits = detail::NumberOfDivergingBits(old_key, new_key);
 
         EntryT* current_entry = &root_;           // An entry.


### PR DESCRIPTION
Fix `relocate()` return type to be `size_t`